### PR TITLE
Add google/auth action

### DIFF
--- a/.github/workflows/test-google-auth.yml
+++ b/.github/workflows/test-google-auth.yml
@@ -32,8 +32,3 @@ jobs:
           "projects/8560181848/locations/global/workloadIdentityPools/github/providers/repo-37af2ab116595bd21e72f6b8478"
           =
           "${{ steps.google-auth.outputs.workload-identity-provider }}"
-      - run: >
-          test
-          "projects/8560181848/locations/global/workloadIdentityPools/github/providers/repo-abc"
-          !=
-          "${{ steps.google-auth.outputs.workload-identity-provider }}"

--- a/.github/workflows/test-google-auth.yml
+++ b/.github/workflows/test-google-auth.yml
@@ -1,0 +1,34 @@
+name: test-google-auth
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-google-auth.yml'
+      - './google/auth/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-google-auth.yml'
+      - './google/auth/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test-google-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./google/auth
+        id: google-auth
+        continue-on-error: true
+        with:
+          repository: elastic/dummy
+      - run: >
+          test
+          "projects/8560181848/locations/global/workloadIdentityPools/github/providers/repo-37af2ab116595bd21e72f6b8478"
+          =
+          "${{ steps.google-auth.outputs.workload-identity-provider }}"

--- a/.github/workflows/test-google-auth.yml
+++ b/.github/workflows/test-google-auth.yml
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - '.github/workflows/test-google-auth.yml'
-      - './google/auth/**'
+      - 'google/auth/**'
   push:
     branches:
       - main
     paths:
       - '.github/workflows/test-google-auth.yml'
-      - './google/auth/**'
+      - 'google/auth/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test-google-auth.yml
+++ b/.github/workflows/test-google-auth.yml
@@ -32,3 +32,8 @@ jobs:
           "projects/8560181848/locations/global/workloadIdentityPools/github/providers/repo-37af2ab116595bd21e72f6b8478"
           =
           "${{ steps.google-auth.outputs.workload-identity-provider }}"
+      - run: >
+          test
+          "projects/8560181848/locations/global/workloadIdentityPools/github/providers/repo-abc"
+          !=
+          "${{ steps.google-auth.outputs.workload-identity-provider }}"

--- a/google/auth/README.md
+++ b/google/auth/README.md
@@ -4,6 +4,19 @@ This is an opinionated GitHub Action to authenticate with GCP.
 It generates a Workload Identity Pool Provider ID based on the repository name, which is compatible with the
 GCP Workload Identity Pool Provider ID we use for Elastic Observability repositories.
 
+### Inputs
+
+| name             | description                    | required | default                    |
+|------------------|--------------------------------|----------|----------------------------|
+| `project-number` | <p>The GCP project number</p>  | `false`  | `8560181848`               |
+| `repository`     | <p>The repository name</p>     | `false`  | `${{ github.repository }}` |
+
+### Outputs
+
+| name                         | description                                             |
+|------------------------------|---------------------------------------------------------|
+| `workload-identity-provider` | <p>The generated Workload Identity Pool Provider ID</p> |
+
 ## Usage
 
 ```yaml

--- a/google/auth/README.md
+++ b/google/auth/README.md
@@ -1,0 +1,18 @@
+# google/auth
+
+This is an opinionated GitHub Action to authenticate with GCP.
+It generates a Workload Identity Pool Provider ID based on the repository name, which is compatible with the
+GCP Workload Identity Pool Provider ID we use for Elastic Observability repositories.
+
+## Usage
+
+```yaml
+jobs:
+  job_id:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: 'actions/checkout@v4' # Checkout needs to happen before using this action
+      - uses: 'elastic/oblt-actions/google/auth@v1'
+```

--- a/google/auth/README.md
+++ b/google/auth/README.md
@@ -4,14 +4,14 @@ This is an opinionated GitHub Action to authenticate with GCP.
 It generates a Workload Identity Pool Provider ID based on the repository name, which is compatible with the
 GCP Workload Identity Pool Provider ID we use for Elastic Observability repositories.
 
-### Inputs
+## Inputs
 
 | name             | description                    | required | default                    |
 |------------------|--------------------------------|----------|----------------------------|
 | `project-number` | <p>The GCP project number</p>  | `false`  | `8560181848`               |
 | `repository`     | <p>The repository name</p>     | `false`  | `${{ github.repository }}` |
 
-### Outputs
+## Outputs
 
 | name                         | description                                             |
 |------------------------------|---------------------------------------------------------|

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -18,3 +18,4 @@ runs:
       with:
         project_id: 'elastic-observability'
         workload_identity_provider: 'projects/8560181848/locations/global/workloadIdentityPools/github/providers/${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}'
+        request_reason: ${{ github.workflow_ref	}}

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -27,11 +27,11 @@ runs:
         import hashlib
         import os
 
-        repository = os.getenv('GH_REPOSITORY')
-        project_number = os.getenv('PROJECT_NUMBER')
+        repository = os.environ['GH_REPOSITORY']
+        project_number = os.environ['PROJECT_NUMBER']
 
         m = hashlib.sha256()
-        m.update(os.getenv(repository).encode('utf-8'))
+        m.update(repository.encode('utf-8'))
         hash = m.hexdigest()[:27]
         prefix = f"projects/{project_number}/locations/global/workloadIdentityPools/github/providers/repo-"
 

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -1,0 +1,20 @@
+name: google/auth
+
+description: |
+  This is an opinionated GitHub Action to authenticate with GCP.
+  It generates a Workload Identity Pool Provider ID based on the repository name, which is compatible with the
+  GCP Workload Identity Pool Provider ID we use for Elastic Observability repositories.
+
+runs:
+  using: composite
+  steps:
+    - name: Generate workloadIdentityPool provider ID
+      id: generate-workload-identity-pool-provider-id
+      run: |
+        HASH=$(echo -n "${GITHUB_REPOSITORY}" | sha256sum | cut -c1-27)
+        echo "workload_identity_provider_id=repo-${HASH}" >> "${GITHUB_OUTPUT}"
+      shell: bash
+    - uses: google-github-actions/auth@v2
+      with:
+        project_id: 'elastic-observability'
+        workload_identity_provider: 'projects/8560181848/locations/global/workloadIdentityPools/github/providers/${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}'

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -14,7 +14,7 @@ runs:
         HASH=$(echo -n "${GITHUB_REPOSITORY}" | sha256sum | cut -c1-27)
         echo "workload_identity_provider_id=repo-${HASH}" >> "${GITHUB_OUTPUT}"
       shell: bash
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
         project_id: 'elastic-observability'
         workload_identity_provider: 'projects/8560181848/locations/global/workloadIdentityPools/github/providers/${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}'

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -5,17 +5,34 @@ description: |
   It generates a Workload Identity Pool Provider ID based on the repository name, which is compatible with the
   GCP Workload Identity Pool Provider ID we use for Elastic Observability repositories.
 
+inputs:
+  project-number:
+    description: 'The GCP project number'
+    default: '8560181848'
+  repository:
+    description: 'The repository name'
+    default: ${{ github.repository }}
+
+outputs:
+    workload-identity-provider:
+      value: ${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}
+      description: 'The generated Workload Identity Pool Provider ID'
+
 runs:
   using: composite
   steps:
     - name: Generate workloadIdentityPool provider ID
       id: generate-workload-identity-pool-provider-id
       run: |
-        HASH=$(echo -n "${GITHUB_REPOSITORY}" | sha256sum | cut -c1-27)
-        echo "workload_identity_provider_id=repo-${HASH}" >> "${GITHUB_OUTPUT}"
+        HASH=$(echo -n "${GH_REPOSITORY}" | sha256sum | cut -c1-27)
+        PREFIX="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/"
+        echo "workload_identity_provider_id=${PREFIX}repo-${HASH}" >> "${GITHUB_OUTPUT}"
       shell: bash
+      env:
+        GH_REPOSITORY: ${{ inputs.repository }}
+        PROJECT_NUMBER: ${{ inputs.project-number }}
     - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
         project_id: 'elastic-observability'
-        workload_identity_provider: 'projects/8560181848/locations/global/workloadIdentityPools/github/providers/${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}'
+        workload_identity_provider: ${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}
         request_reason: ${{ github.workflow_ref	}}

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -27,20 +27,18 @@ runs:
         import hashlib
         import os
 
+        repository = os.getenv('GH_REPOSITORY')
+        project_number = os.getenv('PROJECT_NUMBER')
+
         m = hashlib.sha256()
-        m.update("${{ inputs.repository }}".encode('utf-8'))
+        m.update(os.getenv(repository).encode('utf-8'))
         hash = m.hexdigest()[:27]
-        prefix = f"projects/${{ inputs.project-number }}/locations/global/workloadIdentityPools/github/providers/repo-"
+        prefix = f"projects/{project_number}/locations/global/workloadIdentityPools/github/providers/repo-"
 
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"workload_identity_provider_id={prefix}{hash}")
 
       shell: python
-#      run: |
-#        HASH=$(echo -n "${GH_REPOSITORY}" | sha256sum | cut -c1-27)
-#        PREFIX="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/"
-#        echo "workload_identity_provider_id=${PREFIX}repo-${HASH}" >> "${GITHUB_OUTPUT}"
-#      shell: bash
       env:
         GH_REPOSITORY: ${{ inputs.repository }}
         PROJECT_NUMBER: ${{ inputs.project-number }}

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -24,10 +24,23 @@ runs:
     - name: Generate workloadIdentityPool provider ID
       id: generate-workload-identity-pool-provider-id
       run: |
-        HASH=$(echo -n "${GH_REPOSITORY}" | sha256sum | cut -c1-27)
-        PREFIX="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/"
-        echo "workload_identity_provider_id=${PREFIX}repo-${HASH}" >> "${GITHUB_OUTPUT}"
-      shell: bash
+        import hashlib
+        import os
+
+        m = hashlib.sha256()
+        m.update("${{ inputs.repository }}".encode('utf-8'))
+        hash = m.hexdigest()[:27]
+        prefix = f"projects/${{ inputs.project-number }}/locations/global/workloadIdentityPools/github/providers/repo-"
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"workload_identity_provider_id={prefix}{hash}")
+
+      shell: python
+#      run: |
+#        HASH=$(echo -n "${GH_REPOSITORY}" | sha256sum | cut -c1-27)
+#        PREFIX="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/"
+#        echo "workload_identity_provider_id=${PREFIX}repo-${HASH}" >> "${GITHUB_OUTPUT}"
+#      shell: bash
       env:
         GH_REPOSITORY: ${{ inputs.repository }}
         PROJECT_NUMBER: ${{ inputs.project-number }}

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -33,10 +33,10 @@ runs:
         m = hashlib.sha256()
         m.update(repository.encode('utf-8'))
         hash = m.hexdigest()[:27]
-        prefix = f"projects/{project_number}/locations/global/workloadIdentityPools/github/providers/repo-"
+        id = f"projects/{project_number}/locations/global/workloadIdentityPools/github/providers/repo-{hash}"
 
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            f.write(f"workload_identity_provider_id={prefix}{hash}")
+            f.write(f"workload_identity_provider_id={id}")
 
       shell: python
       env:


### PR DESCRIPTION
Adds the `google/auth` action — an opinionated action to authenticate with the elastic-observability GCP project.