### PR TITLE
Fix dry-run input

### DIFF
--- a/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
@@ -29,5 +29,5 @@ jobs:
         with:
           github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
           target: 'qa'
-          dry-run: ${{ github.event.inputs.dry-run || false }}
+          dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
           cluster-name-prefix: 'foo'


### PR DESCRIPTION
Fix evaluation of `dry-run` input.

use `github.event.inputs.dry-run` if it is defined, else `true`