### PR TITLE
Add docs check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install gh-action-readme
         run: gh extension install reakaleek/gh-action-readme
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: |
           find . -name "action.yml" \
             -exec bash -c 'echo "$(dirname {})/README.md" && gh action-readme update \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ on:
     paths:
       - '**/action.ya?ml'
   pull_request:
-    paths:
-      - '**/action.ya?ml'
+#    paths:
+#      - '**/action.ya?ml'
 
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+---
+# Check if the README.md file is up-to-date with the action.yml file
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/action.ya?ml'
+  pull_request:
+    paths:
+      - '**/action.ya?ml'
+
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gh-action-readme
+        run: gh extension install reakaleek/gh-action-readme
+      - run: |
+          find . -name "action.yml" \
+            -exec bash -c 'echo "$(dirname {})/README.md" && gh action-readme update \
+              --action="$(dirname {})/action.yml" \
+              --readme="$(dirname {})/README.md"' \;
+      - name: Check for changes
+        run: git diff --exit-code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,5 +30,7 @@ jobs:
             -exec bash -c 'echo "$(dirname {})/README.md" && gh action-readme update \
               --action="$(dirname {})/action.yml" \
               --readme="$(dirname {})/README.md"' \;
+        env:
+          VERSION: v1
       - name: Check for changes
         run: git diff --exit-code


### PR DESCRIPTION
Check if `gh action-readme update` produces any diff in action directories.

If `git diff --exit-code` exits with a non-zero exit code the documentation is not up-to-date and the workflow fails


depends on #21 