### PR TITLE
Update action-readme pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/reakaleek/gh-action-readme
-    rev: v0.3.0
+    rev: v0.3.1
     hooks:
       - id: action-readme
         args:


### PR DESCRIPTION
Updating to `v0.3.1` should fix markdown tables with multiline strings.