### PR TITLE
Fix oblt-cli/run action

### DIFF
--- a/oblt-cli/run/action.yml
+++ b/oblt-cli/run/action.yml
@@ -24,8 +24,7 @@ runs:
         slack-channel: ${{ inputs.slack-channel }}
         username: ${{ inputs.username }}
     - name: run oblt-cli
-      run: oblt-cli ${COMMAND} --verbose --disable-banner
+      run: oblt-cli ${{ inputs.command }} --verbose --disable-banner
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        COMMAND: ${{ inputs.command }}


### PR DESCRIPTION
Make the oblt-cli/run action work the same way as in [apm-pipeline-library](https://github.com/elastic/apm-pipeline-library/blob/ddbd11ec95509883f8bf60b7bb0da1a6610b603a/.github/actions/oblt-cli/action.yml#L29).

This is a potential security risk that we need to tackle in a follow-up. But for the sake of migration, I will revert to the original behaviour.

We should be good if we do not use untrusted inputs in the command.

