### PR TITLE
Remove google/auth usage in oblt-cli/create-* actions

### DIFF
--- a/oblt-cli/cluster-create-ccs/README.md
+++ b/oblt-cli/cluster-create-ccs/README.md
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
-      - uses: elastic/oblt-actions/google/auth@v1
       - uses: elastic/oblt-actions/oblt-cli/cluster-create-ccs@v1
         with:
           remote-cluster: 'dev-oblt'

--- a/oblt-cli/cluster-create-custom/README.md
+++ b/oblt-cli/cluster-create-custom/README.md
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: elastic/oblt-actions/google/auth@v1
       - uses: elastic/oblt-actions/git/setup@v1
       - uses: elastic/oblt-actions/oblt-cli/cluster-create-custom@v1
         with:

--- a/oblt-cli/cluster-create-serverless/README.md
+++ b/oblt-cli/cluster-create-serverless/README.md
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: elastic/oblt-actions/google/auth@v1
       - uses: elastic/oblt-actions/git/setup@v1
       - uses: elastic/oblt-actions/oblt-cli/create-serverless@v1
         with:


### PR DESCRIPTION
Remove usage of `elastic/oblt-actions/google/auth` in docs where it's not necessary to avoid confusion.