### PR TITLE
Add if: always() to test jobs with check-dependent-jobs steps

### DIFF
--- a/.github/workflows/test-buildkite-run.yml
+++ b/.github/workflows/test-buildkite-run.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   test:
+    if: always()
     needs:
       - test-no-wait-for
       - test-wait-for

--- a/.github/workflows/test-oblt-cli-cluster-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-custom.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   test:
+    if: always()
     needs:
       - no-gitops
       - gitops

--- a/.github/workflows/test-oblt-cli-cluster-name-validation.yml
+++ b/.github/workflows/test-oblt-cli-cluster-name-validation.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   test:
+    if: always()
     needs:
       - cluster-name
       - cluster-info-file

--- a/.github/workflows/test-slack-notify-result.yml
+++ b/.github/workflows/test-slack-notify-result.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   test:
+    if: always()
     needs:
       - test-auto
       - test-status


### PR DESCRIPTION
Otherwise, the `test` status check is not created if dependent jobs are failing