### PR TITLE
oblt-cli/setup: Skip downloading if file already exists

### DIFF
--- a/.github/workflows/test-oblt-cli-setup.yml
+++ b/.github/workflows/test-oblt-cli-setup.yml
@@ -25,4 +25,7 @@ jobs:
       - uses: ./oblt-cli/setup
         with:
           github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+      - uses: ./oblt-cli/setup
+        with:
+          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
       - run: oblt-cli version

--- a/oblt-cli/setup/download.sh
+++ b/oblt-cli/setup/download.sh
@@ -31,6 +31,7 @@ fi
 
 # Downloads the latest release if OBLT_CLI_VERSION is not set
 gh release download "${OBLT_CLI_VERSION}" \
+  --skip-existing \
   --repo elastic/observability-test-environments \
   -p "${PATTERN}" \
   --output - | tar -xz -C "${BIN_DIR}"


### PR DESCRIPTION
It's just a minor improvement, but the second time the action is used, the execution time is reduced from 3s to 1s.

![image](https://github.com/elastic/oblt-actions/assets/16325797/9358d786-914c-4c1c-a663-304715b27792)

This will be fruitful if a workflow uses multiple oblt-cli/** commands in one job.

