### PR TITLE
oblt-cli/run: Move global flags before command

### DIFF
--- a/oblt-cli/run/action.yml
+++ b/oblt-cli/run/action.yml
@@ -24,7 +24,7 @@ runs:
         slack-channel: ${{ inputs.slack-channel }}
         username: ${{ inputs.username }}
     - name: run oblt-cli
-      run: oblt-cli ${{ inputs.command }} --verbose --disable-banner
+      run: oblt-cli --verbose --disable-banner ${{ inputs.command }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/oblt-cli/run/action.yml
+++ b/oblt-cli/run/action.yml
@@ -24,7 +24,7 @@ runs:
         slack-channel: ${{ inputs.slack-channel }}
         username: ${{ inputs.username }}
     - name: run oblt-cli
-      run: oblt-cli --verbose ${{ inputs.command }} 
+      run: oblt-cli --verbose ${{ inputs.command }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
This helps keeping the flag even if the command is something like `cluster create || true`