### PR TITLE
oblt-cli/setup: Pin oblt-cli version

### DIFF
--- a/.github/workflows/no-test.yml
+++ b/.github/workflows/no-test.yml
@@ -12,7 +12,6 @@ on:
       - '!git/setup/**'
       - '!google/auth/**'
       - '!updatecli/run/**'
-      - '!oblt-cli/setup/**'
       - '!oblt-cli/cluster-name-validation/**'
       - '!oblt-cli/run/**'
 

--- a/.github/workflows/test-oblt-cli-setup.yml
+++ b/.github/workflows/test-oblt-cli-setup.yml
@@ -1,15 +1,8 @@
 name: test-oblt-cli-setup
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/test-oblt-cli-setup.yml'
-      - 'oblt-cli/setup/**'
+  workflow_dispatch: ~
   push:
-    branches:
-      - main
     paths:
       - '.github/workflows/test-oblt-cli-setup.yml'
       - 'oblt-cli/setup/**'

--- a/oblt-cli/setup/README.md
+++ b/oblt-cli/setup/README.md
@@ -13,7 +13,7 @@ Setup oblt-cli for use in GitHub Actions workflows.
 | `github-token`  | The GitHub access token.                                            | `true`   | ` `                |
 | `slack-channel` | The slack channel to notify the status.                             | `false`  | `#observablt-bots` |
 | `username`      | Username to show in the deployments with oblt-cli, format: [a-z0-9] | `false`  | `obltmachine`      |
-| `version`       | Install a specific version of oblt-cli                              | `false`  | ` `                |
+| `version`       | Install a specific version of oblt-cli                              | `false`  | `7.2.2`            |
 <!--/inputs-->
 
 ## Usage

--- a/oblt-cli/setup/action.yml
+++ b/oblt-cli/setup/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
   version:
     description: "Install a specific version of oblt-cli"
-    default: ""
+    default: "7.2.2"
     required: false
 
 runs:


### PR DESCRIPTION
this should help with ensuring no breaking changes can affect our consumers

There is a follow-up to bump the version with `updatecli`