### PR TITLE
feat: use v1 for the time being

### DIFF
--- a/oblt-cli/cluster-create-ccs/action.yml
+++ b/oblt-cli/cluster-create-ccs/action.yml
@@ -94,7 +94,7 @@ runs:
           }
 
 
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/oblt-cli/cluster-create-custom/action.yml
+++ b/oblt-cli/cluster-create-custom/action.yml
@@ -97,7 +97,7 @@ runs:
             core.setOutput('SKIP_RANDOM_NAME', '--skip-random-name')
           }
 
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/oblt-cli/cluster-create-serverless/action.yml
+++ b/oblt-cli/cluster-create-serverless/action.yml
@@ -80,7 +80,7 @@ runs:
         target: ${{ inputs.target }}
         project_type: ${{ inputs.project-type }}
 
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/oblt-cli/cluster-credentials/action.yml
+++ b/oblt-cli/cluster-credentials/action.yml
@@ -13,13 +13,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: elastic/oblt-actions/oblt-cli/cluster-name-validation@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/cluster-name-validation@v1
       id: validation
       with:
         cluster-name: ${{ inputs.cluster-name }}
         cluster-info-file: ${{ inputs.cluster-info-file }}
 
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
 

--- a/oblt-cli/cluster-destroy/action.yml
+++ b/oblt-cli/cluster-destroy/action.yml
@@ -17,13 +17,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: elastic/oblt-actions/oblt-cli/cluster-name-validation@v1.8.1
+    - uses: elastic/oblt-actions/oblt-cli/cluster-name-validation@v1
       id: validation
       with:
         cluster-name: ${{ inputs.cluster-name }}
         cluster-info-file: ${{ inputs.cluster-info-file }}
 
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.2.0
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
         username: ${{ inputs.username }}

--- a/oblt-cli/run/action.yml
+++ b/oblt-cli/run/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.9.2
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1
       with:
         github-token: ${{ inputs.github-token }}
         slack-channel: ${{ inputs.slack-channel }}


### PR DESCRIPTION
As long as we don't have a way to centralise those inter-dependencies somehow let's use `v1`.

I'd probably say if we use `v1` then all the relevant dependencies should be using `v1`, if we use `v1.9.1` then all the dependencies should point to that particular version regardless