### PR TITLE
fix(google/auth): honour the project-id input

### DIFF
--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -44,6 +44,5 @@ runs:
         PROJECT_NUMBER: ${{ inputs.project-number }}
     - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
-        project_id: ${{ inputs.project-number }}
         workload_identity_provider: ${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}
         request_reason: ${{ github.workflow_ref	}}

--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -44,6 +44,6 @@ runs:
         PROJECT_NUMBER: ${{ inputs.project-number }}
     - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
-        project_id: 'elastic-observability'
+        project_id: ${{ inputs.project-number }}
         workload_identity_provider: ${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}
         request_reason: ${{ github.workflow_ref	}}


### PR DESCRIPTION
Probably `project-number` should be renamed for `project-id`... but regardless, the project-id was hardcoded but `project_number` was used somewhere else....

I'm not sure whether this is a bug.