### PR TITLE
Add usage badges

### DIFF
--- a/aws/auth/README.md
+++ b/aws/auth/README.md
@@ -1,4 +1,6 @@
 # <!--name-->aws/auth<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Faws%2Fauth+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-aws-auth](https://github.com/elastic/oblt-actions/actions/workflows/test-aws-auth.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-aws-auth.yml)
 
 <!--description-->

--- a/buildkite/download-artifact/README.md
+++ b/buildkite/download-artifact/README.md
@@ -1,5 +1,6 @@
 # <!--name-->buildkite/download-artifact<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fbuildkite%2Fdownload-artifact+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-buildkite-download-artifact](https://github.com/elastic/oblt-actions/actions/workflows/test-buildkite-download-artifact.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-buildkite-download-artifact.yml)
 
 <!--description-->

--- a/buildkite/run/README.md
+++ b/buildkite/run/README.md
@@ -1,5 +1,6 @@
 # <!--name-->buildkite/run<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fbuildkite%2Frun+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-buildkite-run](https://github.com/elastic/oblt-actions/actions/workflows/test-buildkite-run.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-buildkite-run.yml)
 
 <!--description-->

--- a/check-dependent-jobs/README.md
+++ b/check-dependent-jobs/README.md
@@ -1,5 +1,6 @@
 # <!--name-->check-dependent-jobs<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fcheck-dependent-jobs+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-check-dependent-jobs](https://github.com/elastic/oblt-actions/actions/workflows/test-check-dependent-jobs.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-check-dependent-jobs.yml)
 
 <!--description-->

--- a/git/setup/README.md
+++ b/git/setup/README.md
@@ -1,5 +1,6 @@
 # <!--name-->git/setup<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fgit%2Fsetup+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-git-setup](https://github.com/elastic/oblt-actions/actions/workflows/test-git-setup.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-git-setup.yml)
 
 <!--description-->

--- a/google/auth/README.md
+++ b/google/auth/README.md
@@ -1,5 +1,6 @@
 # <!--name-->google/auth<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fgoogle%2Fauth+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-google-auth](https://github.com/elastic/oblt-actions/actions/workflows/test-google-auth.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-google-auth.yml)
 
 <!--description-->

--- a/oblt-cli/cluster-create-ccs/README.md
+++ b/oblt-cli/cluster-create-ccs/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/cluster-create-ccs<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-create-ccs+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-cluster-create-ccs](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-ccs.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-ccs.yml)
 
 <!--description-->

--- a/oblt-cli/cluster-create-custom/README.md
+++ b/oblt-cli/cluster-create-custom/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/cluster-create-custom<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-create-custom+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-cluster-create-custom](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-custom.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-custom.yml)
 
 <!--description-->

--- a/oblt-cli/cluster-create-serverless/README.md
+++ b/oblt-cli/cluster-create-serverless/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/cluster-create-serverless<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-create-serverless+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-cluster-create-serverless](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-serverless.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-create-serverless.yml)
 
 <!--description-->

--- a/oblt-cli/cluster-credentials/README.md
+++ b/oblt-cli/cluster-credentials/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/cluster-credentials<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-credentials+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-cluster-credentials](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-credentials.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-credentials.yml)
 
 <!--description-->

--- a/oblt-cli/cluster-destroy/README.md
+++ b/oblt-cli/cluster-destroy/README.md
@@ -1,4 +1,7 @@
 # <!--name-->oblt/cli/cluster-destroy<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-destroy+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
 <!--description-->
 Run the oblt-cli wrapper to destroy the given cluster
 <!--/description-->

--- a/oblt-cli/cluster-name-validation/README.md
+++ b/oblt-cli/cluster-name-validation/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/cluster-name-validation<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fcluster-name-validation+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-cluster-name-validation](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-name-validation.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-cluster-name-validation.yml)
 
 <!--description-->

--- a/oblt-cli/run/README.md
+++ b/oblt-cli/run/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/run<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Frun+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-run](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-run.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-run.yml)
 
 <!--description-->

--- a/oblt-cli/setup/README.md
+++ b/oblt-cli/setup/README.md
@@ -1,5 +1,6 @@
 # <!--name-->oblt-cli/setup<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fsetup+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-oblt-cli-setup](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-setup.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-setup.yml)
 
 <!--description-->

--- a/slack/notify-result/README.md
+++ b/slack/notify-result/README.md
@@ -1,5 +1,6 @@
 # <!--name-->slack/notify-result<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fslack%2Fnotify-result+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-slack-notify-result](https://github.com/elastic/oblt-actions/actions/workflows/test-slack-notify-result.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-slack-notify-result.yml)
 
 <!--description-->

--- a/slack/send/README.md
+++ b/slack/send/README.md
@@ -1,5 +1,6 @@
 # <!--name-->slack/send<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fslack%2Fsend+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-slack-send](https://github.com/elastic/oblt-actions/actions/workflows/test-slack-send.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-slack-send.yml)
 
 ## Inputs

--- a/snapshoty/run/README.md
+++ b/snapshoty/run/README.md
@@ -1,5 +1,6 @@
 # <!--name-->snapshoty/run<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fsnapshoty%2Frun+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 
 <!--description-->
 The best way to handle snapshot lifecycle.

--- a/updatecli/install/README.md
+++ b/updatecli/install/README.md
@@ -1,5 +1,7 @@
 # <!--name-->updatecli/install<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fupdatecli%2Finstall+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
 <!--description-->
 This is an opinionated GitHub Action to install the updatecli
 <!--/description-->

--- a/updatecli/run-and-notify/README.md
+++ b/updatecli/run-and-notify/README.md
@@ -1,5 +1,7 @@
 # <!--name-->updatecli/run-and-notify<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fupdatecli%2Frun-and-notify+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
 > [!WARNING]
 > *Deprecated* Will be removed in a future release.
 > Please use the [updatecli/run](../run/README.md) action with the [slack/send](../../slack/send/README.md) action instead.

--- a/updatecli/run/README.md
+++ b/updatecli/run/README.md
@@ -1,5 +1,7 @@
 # <!--name-->updatecli/run<!--/name-->
 
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fupdatecli%2Frun+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
 ## Inputs
 
 <!--inputs-->


### PR DESCRIPTION
Adds a badge like

<img width="526" alt="image" src="https://github.com/elastic/oblt-actions/assets/16325797/cb91c300-2e23-41b9-8ab6-37c21621ea2b">

that leads to github search code showing where the action is used

---

Example badge for `elastic/oblt-actions/aws/auth`: [![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Faws%2Fauth+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
