### PR TITLE
fix(google/auth): tabs are invalid

### DIFF
--- a/google/auth/action.yml
+++ b/google/auth/action.yml
@@ -45,4 +45,4 @@ runs:
     - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
         workload_identity_provider: ${{ steps.generate-workload-identity-pool-provider-id.outputs.workload_identity_provider_id }}
-        request_reason: ${{ github.workflow_ref	}}
+        request_reason: ${{ github.workflow_ref }}


### PR DESCRIPTION
This is not permitted by the YAML spec:
- https://yaml.org/spec/1.2-old/spec.html#id2777534