### PR TITLE
chore: bump oblt setup version

### DIFF
--- a/oblt-cli/run/action.yml
+++ b/oblt-cli/run/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: elastic/oblt-actions/oblt-cli/setup@v1.10.0
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1.11.0
       with:
         github-token: ${{ inputs.github-token }}
         slack-channel: ${{ inputs.slack-channel }}


### PR DESCRIPTION
It is using the previous version