### PR TITLE
Add `test-report` action

### DIFF
--- a/test-report/README.md
+++ b/test-report/README.md
@@ -1,0 +1,52 @@
+# <!--name-->Test report<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Ftest-report+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
+<!--description-->
+Shows test results in GitHub UI: .NET (xUnit, NUnit, MSTest), Dart, Flutter, Java (JUnit), JavaScript (JEST, Mocha)
+<!--/description-->
+
+## Inputs
+
+<!--inputs-->
+| Name            | Description                                                                                                                                                                                                                                           | Required | Default       |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| `artifact`      | Name or regex of artifact containing test results                                                                                                                                                                                                     | `false`  | `all`         |
+| `name`          | Name of the check run                                                                                                                                                                                                                                 | `false`  | `JUnit Tests` |
+| `path`          | Coma separated list of paths to test results<br>Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)<br>All matched result files must be of same format<br>                                                                        | `true`   | `**/*.xml`    |
+| `reporter`      | Format of test results. Supported options:<br>  - dart-json<br>  - dotnet-trx<br>  - flutter-json<br>  - java-junit<br>  - jest-junit<br>  - mocha-json<br>  - mochawesome-json<br>                                                                   | `true`   | `java-junit`  |
+| `list-suites`   | Limits which test suites are listed. Supported options:<br>  - all<br>  - failed<br>                                                                                                                                                                  | `true`   | `all`         |
+| `list-tests`    | Limits which test cases are listed. Supported options:<br>  - all<br>  - failed<br>  - none<br>                                                                                                                                                       | `true`   | `all`         |
+| `fail-on-error` | Set this action as failed if test report contain any failed test                                                                                                                                                                                      | `true`   | `true`        |
+| `only-summary`  | Allows you to generate only the summary.<br>If enabled, the report will contain a table listing each test results file and the number of passed,<br>failed, and skipped tests.<br>Detailed listing of test suites and test cases will be skipped.<br> | `false`  | `false`       |
+| `output-to`     | The location to write the report to. Supported options:<br>  - checks<br>  - step-summary<br>                                                                                                                                                         | `false`  | `checks`      |
+<!--/inputs-->
+
+## Usage
+
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+on:
+  workflow_run:
+    workflows:
+      - test
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/test-report@v1
+        with:
+          artifact: test-results
+          name: JUnit Tests
+          path: "**/*-python-agent-junit.xml"
+          reporter: java-junit
+```
+<!--/usage-->

--- a/test-report/README.md
+++ b/test-report/README.md
@@ -1,4 +1,4 @@
-# <!--name-->Test report<!--/name-->
+# <!--name-->test-report<!--/name-->
 
 [![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Ftest-report+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 

--- a/test-report/action.yml
+++ b/test-report/action.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Test report'
+name: 'test-report'
 description: |
   Shows test results in GitHub UI: .NET (xUnit, NUnit, MSTest), Dart, Flutter, Java (JUnit), JavaScript (JEST, Mocha)
 inputs:

--- a/test-report/action.yml
+++ b/test-report/action.yml
@@ -1,0 +1,81 @@
+---
+name: 'Test report'
+description: |
+  Shows test results in GitHub UI: .NET (xUnit, NUnit, MSTest), Dart, Flutter, Java (JUnit), JavaScript (JEST, Mocha)
+inputs:
+  artifact:
+    description: Name or regex of artifact containing test results
+    default: 'all'
+    required: false
+  name:
+    description: Name of the check run
+    default: 'JUnit Tests'
+    required: false
+  path:
+    description: |
+      Coma separated list of paths to test results
+      Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
+      All matched result files must be of same format
+    default: '**/*.xml'
+    required: true
+  reporter:
+    description: |
+      Format of test results. Supported options:
+        - dart-json
+        - dotnet-trx
+        - flutter-json
+        - java-junit
+        - jest-junit
+        - mocha-json
+        - mochawesome-json
+    default: 'java-junit'
+    required: true
+  list-suites:
+    description: |
+      Limits which test suites are listed. Supported options:
+        - all
+        - failed
+    required: true
+    default: 'all'
+  list-tests:
+    description: |
+      Limits which test cases are listed. Supported options:
+        - all
+        - failed
+        - none
+    required: true
+    default: 'all'
+  fail-on-error:
+    description: Set this action as failed if test report contain any failed test
+    required: true
+    default: 'true'
+  only-summary:
+    description: |
+      Allows you to generate only the summary.
+      If enabled, the report will contain a table listing each test results file and the number of passed,
+      failed, and skipped tests.
+      Detailed listing of test suites and test cases will be skipped.
+    default: 'false'
+    required: false
+  output-to:
+    description: |
+      The location to write the report to. Supported options:
+        - checks
+        - step-summary
+    default: 'checks'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Report test results
+      uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
+      with:
+        artifact: ${{ inputs.artifact }}
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        reporter: ${{ inputs.reporter }}
+        list-suites: ${{ inputs.list-suites }}
+        list-tests: ${{ inputs.list-tests }}
+        fail-on-error: ${{ inputs.fail-on-error }}
+        only-summary: ${{ inputs.only-summary }}
+        output-to: ${{ inputs.output-to }}


### PR DESCRIPTION
Migrated from https://github.com/elastic/apm-pipeline-library/blob/main/.github/actions/test-report/action.yml

Tested at https://github.com/elastic/observability-robots-playground/pull/58/checks?check_run_id=29922269242