### PR TITLE
feat(await-maven-artifact): migrate from https://github.com/elastic/apm-pipeline-library

### DIFF
--- a/.github/workflows/test-maven-await-artifact.yml
+++ b/.github/workflows/test-maven-await-artifact.yml
@@ -1,0 +1,29 @@
+name: test-aws-auth
+
+on:
+  pull_request:
+    paths:
+      - 'maven/await-artifact/**'
+      - '.github/workflows/test-maven-await-artifact.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'maven/await-artifact/**'
+      - '.github/workflows/test-maven-await-artifact.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./maven/await-artifact
+        id: aws-auth
+        continue-on-error: true
+        with:
+          artifact-id: "apm-agent-java"
+          group-id: "co.elastic.apm"
+          version: "1.50.0"

--- a/.github/workflows/test-maven-await-artifact.yml
+++ b/.github/workflows/test-maven-await-artifact.yml
@@ -1,4 +1,4 @@
-name: test-aws-auth
+name: test-maven-await-artifact
 
 on:
   pull_request:
@@ -18,12 +18,13 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
       - uses: ./maven/await-artifact
         id: aws-auth
         continue-on-error: true
         with:
-          artifact-id: "apm-agent-java"
+          artifact-id: "elastic-apm-agent"
           group-id: "co.elastic.apm"
           version: "1.50.0"

--- a/.github/workflows/test-maven-await-artifact.yml
+++ b/.github/workflows/test-maven-await-artifact.yml
@@ -18,12 +18,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
       - uses: ./maven/await-artifact
-        id: aws-auth
-        continue-on-error: true
+        timeout-minutes: 1
         with:
           artifact-id: "elastic-apm-agent"
           group-id: "co.elastic.apm"

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -1,0 +1,45 @@
+# <!--name-->maven/await-artifact<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fmaven%2Fawait-artifact+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-maven-await-artifact](https://github.com/elastic/oblt-actions/actions/workflows/test-elastic-active-branches.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-maven-await-artifact.yml)
+
+<!--description-->
+Waits for an artifact to be available on maven central
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name          | Description                         | Required | Default |
+|---------------|-------------------------------------|----------|---------|
+| `artifact-id` | Maven artifact-ID of the artifact   | `true`   | ` `     |
+| `group-id`    | Maven group-ID of the artifact      | `true`   | ` `     |
+| `version`     | Version of the artifact to wait for | `true`   | ` `     |
+<!--/inputs-->
+
+
+## Usage
+
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
+        required: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # ...
+
+      - uses: elastic/oblt-actions/maven/await-artifact@v1
+        with:
+          group-id: "co.elastic.apm"
+          artifact-id: "apm-agent-java"
+          version: "${{ inputs.version }}"
+
+      # ...
+```
+<!--/usage-->

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -7,6 +7,9 @@
 Waits for an artifact to be available on maven central
 <!--/description-->
 
+NOTE: this action does not timeout, hence you need to configure your GitHub workflow accordingly.
+      See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes
+
 ## Inputs
 <!--inputs-->
 | Name          | Description                         | Required | Default |
@@ -29,17 +32,17 @@ on:
         description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
         required: true
 jobs:
+
   deploy:
     runs-on: ubuntu-latest
     steps:
       # ...
-
       - uses: elastic/oblt-actions/maven/await-artifact@v1
+        timeout-minutes: 10
         with:
           group-id: "co.elastic.apm"
           artifact-id: "apm-agent-java"
           version: "${{ inputs.version }}"
-
       # ...
 ```
 <!--/usage-->

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -1,0 +1,29 @@
+name: maven/await-artifact
+description: |
+  Waits for an artifact to be available on maven central
+inputs:
+  artifact-id:
+    description: 'Maven artifact-ID of the artifact'
+    required: true
+  group-id:
+    description: 'Maven group-ID of the artifact'
+    required: true
+  version:
+    description: 'Version of the artifact to wait for'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Wait for artifact to be available on maven central
+      shell: bash
+      run: |
+        full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${{ env.GROUP_ID }}&a=${{ env.ARTIFACT_ID }}&v=${{ env.VERSION }}"
+        until curl -fs -I -L "${full_url}" > /dev/null
+        do
+          echo "Artifact '${{ env.GROUP_ID }}:${{ env.ARTIFACT_ID }}:${{ env.VERSION }}' not found on maven central. Sleeping 30 seconds, retrying afterwards"
+          sleep 30s
+        done
+      env:
+        ARTIFACT_ID: ${{ inputs.artifact-id }}
+        GROUP_ID: ${{ inputs.group-id }}
+        VERSION: ${{ inputs.version }}

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -17,10 +17,10 @@ runs:
     - name: Wait for artifact to be available on maven central
       shell: bash
       run: |
-        full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${{ env.GROUP_ID }}&a=${{ env.ARTIFACT_ID }}&v=${{ env.VERSION }}"
+        full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${VERSION}"
         until curl -fs -I -L "${full_url}" > /dev/null
         do
-          echo "Artifact '${{ env.GROUP_ID }}:${{ env.ARTIFACT_ID }}:${{ env.VERSION }}' not found on maven central. Sleeping 30 seconds, retrying afterwards"
+          echo "Artifact ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} not found on maven central. Sleeping 30 seconds, retrying afterwards"
           sleep 30s
         done
       env:


### PR DESCRIPTION

See
https://github.com/elastic/apm-pipeline-library/tree/main/.github/actions/await-maven-artifact


I also renamed the inputs to use `-` as a separator and use env to help with [securing the thing](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)