### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.github/workflows/test-oblt-cli-cluster-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-custom.yml
@@ -36,9 +36,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-create-custom
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: false
@@ -50,9 +62,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-create-custom
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: true
@@ -64,9 +88,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-create-custom
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
@@ -22,9 +22,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-create-serverless
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           target: 'qa'
           dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
           cluster-name-prefix: 'foo'

--- a/.github/workflows/test-oblt-cli-cluster-credentials.yml
+++ b/.github/workflows/test-oblt-cli-cluster-credentials.yml
@@ -17,8 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/google/auth@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-credentials
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           cluster-name: 'dev-oblt'
       - run: curl -X GET "${ELASTICSEARCH_HOST}/_cat/indices?v" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"

--- a/.github/workflows/test-oblt-cli-create-ccs.yml
+++ b/.github/workflows/test-oblt-cli-create-ccs.yml
@@ -23,9 +23,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/cluster-create-ccs
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           remote-cluster: 'release-oblt'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli-run.yml
+++ b/.github/workflows/test-oblt-cli-run.yml
@@ -22,7 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "READ"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/run
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           command: cluster --help

--- a/.github/workflows/test-oblt-cli-run.yml
+++ b/.github/workflows/test-oblt-cli-run.yml
@@ -30,7 +30,7 @@ jobs:
           private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
           permissions: >-
             {
-              "contents": "READ"
+              "contents": "read"
             }
           repositories: >-
             ["observability-test-environments"]

--- a/.github/workflows/test-oblt-cli-setup.yml
+++ b/.github/workflows/test-oblt-cli-setup.yml
@@ -31,10 +31,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/setup
         with:
           version: 7.2.2
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
       - name: Verify oblt-cli version
         run: |
           version=$(oblt-cli version 2>&1)
@@ -44,12 +56,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - name: Setup version file
         run: |
           echo "7.2.5" > .oblt-cli-version
       - uses: ./oblt-cli/setup
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           version-file: .oblt-cli-version
       - name: Verify oblt-cli version
         run: |
@@ -60,9 +84,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/setup
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
       - name: Verify oblt-cli version
         run: |
           version=$(oblt-cli version 2>&1)
@@ -73,6 +109,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - name: Setup version file
         run: |
           cat <<EOF > .tool-versions
@@ -83,7 +131,7 @@ jobs:
           EOF
       - uses: ./oblt-cli/setup
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           version-file: .tool-versions
       - name: Verify oblt-cli version
         run: |
@@ -94,11 +142,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/setup
         id: oblt-cli-setup
         continue-on-error: true
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           version-file: non-existing-file
       - name: Verify step failed
         if: steps.oblt-cli-setup.outcome != 'failure'
@@ -108,10 +168,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
       - uses: ./oblt-cli/setup
         id: oblt-cli-setup
         with:
-          github-token: ${{ secrets.OBLT_CLI_GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
           version: 7.3.0
           version-file: non-existing-file
       - name: Verify oblt-cli version


### PR DESCRIPTION
## What does this PR do?

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.
This is the very first attempt, there will be some follow-ups to update some of the remaining workflows.

## Why is it important?

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the GH workflow requires to run in terms of access
* GitHub Token with Permissions does not trigger GitHub builds 

#### Implementation details

Use `tibdex/github-app-token` with the required permissions and the repository scope
Remove the `permissions` configuration in the GH workflow.
Configure the github-token with the ephemeral token

