### PR TITLE
feat: support wait for maven central

### DIFF
--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -5,6 +5,8 @@
 
 <!--description-->
 Waits for an artifact to be available on maven central or the sonatype proxy maven central.
+With default values, we just wait for the publication to complete on `sonatype`, but the actual availability in maven central might not be ready yet.
+With `true`, we wait for the artifact to be published in maven central, this should be used when building other artifacts by downloading from maven central, which is for example quite common for docker images.
 <!--/description-->
 
 NOTE: this action does not timeout, hence you need to configure your GitHub workflow accordingly.

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -19,8 +19,8 @@ NOTE: this action does not timeout, hence you need to configure your GitHub work
 | `artifact-id`               | Maven artifact-ID of the artifact                                                    | `true`   | ` `     |
 | `group-id`                  | Maven group-ID of the artifact                                                       | `true`   | ` `     |
 | `version`                   | Version of the artifact to wait for                                                  | `true`   | ` `     |
-| `wait-for-sonatype-central` | Whether to wait for the artifact to be available in the sonatype central repository. | `false`  | `true`  |
-| `wait-for-maven-central`    | Whether to wait for the artifact to be available in the maven central repository.    | `false`  | `false` |
+| `sonatype-central` | Whether to wait for the artifact to be available in the sonatype central repository. | `false`  | `true`  |
+| `maven-central`    | Whether to wait for the artifact to be available in the maven central repository.    | `false`  | `false` |
 <!--/inputs-->
 
 

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -12,11 +12,12 @@ NOTE: this action does not timeout, hence you need to configure your GitHub work
 
 ## Inputs
 <!--inputs-->
-| Name          | Description                         | Required | Default |
-|---------------|-------------------------------------|----------|---------|
-| `artifact-id` | Maven artifact-ID of the artifact   | `true`   | ` `     |
-| `group-id`    | Maven group-ID of the artifact      | `true`   | ` `     |
-| `version`     | Version of the artifact to wait for | `true`   | ` `     |
+| Name                     | Description                                                                       | Required | Default |
+|--------------------------|-----------------------------------------------------------------------------------|----------|---------|
+| `artifact-id`            | Maven artifact-ID of the artifact                                                 | `true`   | ` `     |
+| `group-id`               | Maven group-ID of the artifact                                                    | `true`   | ` `     |
+| `version`                | Version of the artifact to wait for                                               | `true`   | ` `     |
+| `wait-for-maven-central` | Whether to wait for the artifact to be available in the maven central repository. | `false`  | `false` |
 <!--/inputs-->
 
 

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -4,7 +4,7 @@
 [![test-maven-await-artifact](https://github.com/elastic/oblt-actions/actions/workflows/test-elastic-active-branches.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-maven-await-artifact.yml)
 
 <!--description-->
-Waits for an artifact to be available on maven central
+Waits for an artifact to be available on maven central or the sonatype proxy maven central.
 <!--/description-->
 
 NOTE: this action does not timeout, hence you need to configure your GitHub workflow accordingly.
@@ -12,12 +12,13 @@ NOTE: this action does not timeout, hence you need to configure your GitHub work
 
 ## Inputs
 <!--inputs-->
-| Name                     | Description                                                                       | Required | Default |
-|--------------------------|-----------------------------------------------------------------------------------|----------|---------|
-| `artifact-id`            | Maven artifact-ID of the artifact                                                 | `true`   | ` `     |
-| `group-id`               | Maven group-ID of the artifact                                                    | `true`   | ` `     |
-| `version`                | Version of the artifact to wait for                                               | `true`   | ` `     |
-| `wait-for-maven-central` | Whether to wait for the artifact to be available in the maven central repository. | `false`  | `false` |
+| Name                        | Description                                                                          | Required | Default |
+|-----------------------------|--------------------------------------------------------------------------------------|----------|---------|
+| `artifact-id`               | Maven artifact-ID of the artifact                                                    | `true`   | ` `     |
+| `group-id`                  | Maven group-ID of the artifact                                                       | `true`   | ` `     |
+| `version`                   | Version of the artifact to wait for                                                  | `true`   | ` `     |
+| `wait-for-sonatype-central` | Whether to wait for the artifact to be available in the sonatype central repository. | `false`  | `true`  |
+| `wait-for-maven-central`    | Whether to wait for the artifact to be available in the maven central repository.    | `false`  | `false` |
 <!--/inputs-->
 
 

--- a/maven/await-artifact/README.md
+++ b/maven/await-artifact/README.md
@@ -12,13 +12,14 @@ With `true`, we wait for the artifact to be published in maven central, this sho
 NOTE: this action does not timeout, hence you need to configure your GitHub workflow accordingly.
       See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes
 
+
 ## Inputs
 <!--inputs-->
-| Name                        | Description                                                                          | Required | Default |
-|-----------------------------|--------------------------------------------------------------------------------------|----------|---------|
-| `artifact-id`               | Maven artifact-ID of the artifact                                                    | `true`   | ` `     |
-| `group-id`                  | Maven group-ID of the artifact                                                       | `true`   | ` `     |
-| `version`                   | Version of the artifact to wait for                                                  | `true`   | ` `     |
+| Name               | Description                                                                          | Required | Default |
+|--------------------|--------------------------------------------------------------------------------------|----------|---------|
+| `artifact-id`      | Maven artifact-ID of the artifact                                                    | `true`   | ` `     |
+| `group-id`         | Maven group-ID of the artifact                                                       | `true`   | ` `     |
+| `version`          | Version of the artifact to wait for                                                  | `true`   | ` `     |
 | `sonatype-central` | Whether to wait for the artifact to be available in the sonatype central repository. | `false`  | `true`  |
 | `maven-central`    | Whether to wait for the artifact to be available in the maven central repository.    | `false`  | `false` |
 <!--/inputs-->

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -1,6 +1,6 @@
 name: maven/await-artifact
 description: |
-  Waits for an artifact to be available on maven central
+  Waits for an artifact to be available on maven central or the sonatype proxy maven central.
 inputs:
   artifact-id:
     description: 'Maven artifact-ID of the artifact'
@@ -11,6 +11,10 @@ inputs:
   version:
     description: 'Version of the artifact to wait for'
     required: true
+  wait-for-sonatype-central:
+    description: 'Whether to wait for the artifact to be available in the sonatype central repository.'
+    default: true
+    required: false
   wait-for-maven-central:
     description: 'Whether to wait for the artifact to be available in the maven central repository.'
     default: false
@@ -18,7 +22,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Wait for artifact to be available on proxy maven central
+    - name: Wait for artifact to be available on proxy sonatype maven central
+      if: ${{ inputs.wait-for-sonatype-central == 'true' }}
       shell: bash
       run: |
         TIME=30

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         TIME=30
-        GROUP_FOLDER="${GROUP_ID//./\/}"
+        GROUP_FOLDER="${GROUP_ID//.//}"
         full_url="https://repo.maven.apache.org/maven2/${GROUP_FOLDER}/${ARTIFACT_ID}/${VERSION}"
         until curl -fs -I -L "${full_url}" > /dev/null
         do

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -13,11 +13,11 @@ inputs:
   version:
     description: 'Version of the artifact to wait for'
     required: true
-  wait-for-sonatype-central:
+  sonatype-central:
     description: 'Whether to wait for the artifact to be available in the sonatype central repository.'
     default: true
     required: false
-  wait-for-maven-central:
+  maven-central:
     description: 'Whether to wait for the artifact to be available in the maven central repository.'
     default: false
     required: false
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Wait for artifact to be available on proxy sonatype maven central
-      if: ${{ inputs.wait-for-sonatype-central == 'true' }}
+      if: ${{ inputs.sonatype-central == 'true' }}
       shell: bash
       run: |
         TIME=30
@@ -41,7 +41,7 @@ runs:
         VERSION: ${{ inputs.version }}
 
     - name: Wait for artifact to be available on maven central
-      if: ${{ inputs.wait-for-maven-central == 'true' }}
+      if: ${{ inputs.maven-central == 'true' }}
       shell: bash
       run: |
         TIME=30

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -1,8 +1,8 @@
 name: maven/await-artifact
 description: |
   Waits for an artifact to be available on maven central or the sonatype proxy maven central.
-  With default values, we just wait for the publication to complete on sonatype, but the actual availability in maven central might not be ready yet.
-  With 'true' we wait for the artifact to be published in maven central, this should be used when building other artifacts by downloading from maven central, which is for example quite common for docker images.
+  With default values, we just wait for the publication to complete on `sonatype`, but the actual availability in maven central might not be ready yet.
+  With `true`, we wait for the artifact to be published in maven central, this should be used when building other artifacts by downloading from maven central, which is for example quite common for docker images.
 inputs:
   artifact-id:
     description: 'Maven artifact-ID of the artifact'

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -1,6 +1,8 @@
 name: maven/await-artifact
 description: |
   Waits for an artifact to be available on maven central or the sonatype proxy maven central.
+  With default values, we just wait for the publication to complete on sonatype, but the actual availability in maven central might not be ready yet.
+  With 'true' we wait for the artifact to be published in maven central, this should be used when building other artifacts by downloading from maven central, which is for example quite common for docker images.
 inputs:
   artifact-id:
     description: 'Maven artifact-ID of the artifact'

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -11,17 +11,39 @@ inputs:
   version:
     description: 'Version of the artifact to wait for'
     required: true
+  wait-for-maven-central:
+    description: 'Whether to wait for the artifact to be available in the maven central repository.'
+    default: false
+    required: false
 runs:
   using: "composite"
   steps:
-    - name: Wait for artifact to be available on maven central
+    - name: Wait for artifact to be available on proxy maven central
       shell: bash
       run: |
+        TIME=30
         full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${VERSION}"
         until curl -fs -I -L "${full_url}" > /dev/null
         do
-          echo "Artifact ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} not found on maven central. Sleeping 30 seconds, retrying afterwards"
-          sleep 30s
+          echo "Artifact ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} not found on proxy maven central. Sleeping ${WAIT_SECONDS} seconds, retrying afterwards"
+          sleep ${WAIT_SECONDS}s
+        done
+      env:
+        ARTIFACT_ID: ${{ inputs.artifact-id }}
+        GROUP_ID: ${{ inputs.group-id }}
+        VERSION: ${{ inputs.version }}
+
+    - name: Wait for artifact to be available on maven central
+      if: ${{ inputs.wait-for-maven-central == 'true' }}
+      shell: bash
+      run: |
+        TIME=30
+        GROUP_FOLDER="${GROUP_ID//./\/}"
+        full_url="https://repo.maven.apache.org/maven2/${GROUP_FOLDER}/${ARTIFACT_ID}/${VERSION}"
+        until curl -fs -I -L "${full_url}" > /dev/null
+        do
+          echo "Artifact ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} not found on maven central. Sleeping ${WAIT_SECONDS} seconds, retrying afterwards"
+          sleep ${WAIT_SECONDS}s
         done
       env:
         ARTIFACT_ID: ${{ inputs.artifact-id }}


### PR DESCRIPTION
closes https://github.com/elastic/oblt-actions/issues/132

### What

Support to query the maven central if `wait-for-maven-central` is set to `true` by default is not the case.

