### PR TITLE
feat: undeploy-my-kibana

### DIFF
--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -31,6 +31,7 @@ jobs:
           private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
           permissions: >-
             {
+              "contents": "read",
               "issues": "write"
             }
           repositories: >-

--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -39,4 +39,5 @@ jobs:
       - uses: ./oblt-cli/undeploy-my-kibana
         with:
           github-token: ${{ steps.get_token.outputs.token }}
-          pull-request: 1
+          pull-request: '187489'
+          repository: 'elastic/kibana'

--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -1,0 +1,42 @@
+name: test-undeploy-my-kibana
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-undeploy-my-kibana.yml'
+      - 'oblt-cli/undeploy-my-kibana/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-undeploy-my-kibana.yml'
+      - 'oblt-cli/undeploy-my-kibana/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "issues": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
+
+      - uses: ./oblt-cli/undeploy-my-kibana
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          pull-request: 1

--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -18,27 +18,52 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  undeploy-my-kibana:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get token
-        id: get_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          permissions: >-
-            {
-              "contents": "read",
-              "issues": "write"
-            }
-          repositories: >-
-            ["observability-test-environments"]
-
       - uses: ./oblt-cli/undeploy-my-kibana
         with:
-          github-token: ${{ steps.get_token.outputs.token }}
+          github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
           pull-request: '187489'
           repository: 'elastic/kibana'
+
+  no-parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./oblt-cli/undeploy-my-kibana
+        id: validation
+        continue-on-error: true
+      - name: Assert is failure if no parameters
+        run: test "${{steps.validation.outcome}}" = "failure"
+
+  all-parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./oblt-cli/undeploy-my-kibana
+        id: validation
+        continue-on-error: true
+        with:
+          github-app-id: "app"
+          github-app-private-key: "key"
+          github-token: "foo"
+      - name: Assert is failure if all parameters
+        run: test "${{steps.validation.outcome}}" = "failure"
+
+  test:
+    if: always()
+    needs:
+      - undeploy-my-kibana
+      - no-parameters
+      - all-parameters
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}

--- a/oblt-cli/undeploy-my-kibana/README.md
+++ b/oblt-cli/undeploy-my-kibana/README.md
@@ -1,0 +1,47 @@
+# <!--name-->oblt-cli/undeploy-my-kibana<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fundeploy-my-kibana+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-oblt-cli-cluster-name-validation](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml)
+
+<!--description-->
+Undeploy my kibana given the Pull Request
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name           | Description                | Required | Default                                   |
+|----------------|----------------------------|----------|-------------------------------------------|
+| `pull-request` | The GitHub Pull Request ID | `false`  | `${{ github.event.pull_request.number }}` |
+| `repository`   | The GitHub repository      | `false`  | `${{ github.repository }}`                |
+| `github-token` | The GitHub access token.   | `true`   | ` `                                       |
+<!--/inputs-->
+
+## Outputs
+<!--outputs-->
+| Name    | Description                                                   |
+|---------|---------------------------------------------------------------|
+| `issue` | The GitHub issue that has been created to destroy the cluster |
+<!--/outputs-->
+
+## Usage
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+name: undeploy-my-kibana
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  undeploy-my-kibana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/oblt-cli/undeploy-my-kibana@v1
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+
+```
+<!--/usage-->

--- a/oblt-cli/undeploy-my-kibana/README.md
+++ b/oblt-cli/undeploy-my-kibana/README.md
@@ -9,11 +9,13 @@ Undeploy my kibana given the Pull Request
 
 ## Inputs
 <!--inputs-->
-| Name           | Description                | Required | Default                                   |
-|----------------|----------------------------|----------|-------------------------------------------|
-| `pull-request` | The GitHub Pull Request ID | `false`  | `${{ github.event.pull_request.number }}` |
-| `repository`   | The GitHub repository      | `false`  | `${{ github.repository }}`                |
-| `github-token` | The GitHub access token.   | `true`   | ` `                                       |
+| Name                     | Description                                                 | Required | Default                                   |
+|--------------------------|-------------------------------------------------------------|----------|-------------------------------------------|
+| `pull-request`           | The GitHub Pull Request ID                                  | `false`  | `${{ github.event.pull_request.number }}` |
+| `repository`             | The GitHub repository                                       | `false`  | `${{ github.repository }}`                |
+| `github-token`           | The GitHub Personal Access Token.                           | `false`  | ` `                                       |
+| `github-app-id`          | The GitHub App ID to generate the ephemeral token.          | `false`  | ` `                                       |
+| `github-app-private-key` | The GitHub App Private Key to generate the ephemeral token. | `false`  | ` `                                       |
 <!--/inputs-->
 
 ## Outputs

--- a/oblt-cli/undeploy-my-kibana/README.md
+++ b/oblt-cli/undeploy-my-kibana/README.md
@@ -37,6 +37,7 @@ permissions:
 
 jobs:
   undeploy-my-kibana:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:deploy-observability')
     runs-on: ubuntu-latest
     steps:
       - uses: elastic/oblt-actions/oblt-cli/undeploy-my-kibana@v1

--- a/oblt-cli/undeploy-my-kibana/action.yml
+++ b/oblt-cli/undeploy-my-kibana/action.yml
@@ -35,7 +35,7 @@ runs:
         github-org: "elastic"
         github-token: ${{ inputs.github-token }}
 
-    - if: steps.is_elastic_member.outputs.result == true
+    - if: contains(steps.is_elastic_member.outputs.result, 'true')
       name: Create GitHub issue body
       id: undeploy-my-kibana
       run: |-

--- a/oblt-cli/undeploy-my-kibana/action.yml
+++ b/oblt-cli/undeploy-my-kibana/action.yml
@@ -1,0 +1,66 @@
+name: 'oblt-cli/undeploy-my-kibana'
+description: 'Undeploy my kibana given the Pull Request'
+inputs:
+  pull-request:
+    description: 'The GitHub Pull Request ID'
+    default: ${{ github.event.pull_request.number }}
+  repository:
+    description: 'The GitHub repository'
+    default: ${{ github.repository }}
+  github-token:
+    description: 'The GitHub access token.'
+    required: true
+
+outputs:
+  issue:
+    description: 'The GitHub issue that has been created to destroy the cluster'
+    value: ${{ steps.undeploy-my-kibana.outputs.issue }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: gh_api_pr_author
+      name: Gather PR Owner
+      run: |-
+        PR_AUTHOR=$(gh pr view ${{ inputs.pull-request }} --repo ${{ inputs.repository }} --json author --jq .author.login)
+        echo "result=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      shell: bash
+
+    - uses: elastic/oblt-actions/github/is-member-of@v1
+      id: is_elastic_member
+      with:
+        github-user: ${{ steps.gh_api_pr_author.outputs.result }}
+        github-org: "elastic"
+        github-token: ${{ inputs.github-token }}
+
+    - if: steps.is_elastic_member.outputs.result == true
+      name: Create GitHub issue body
+      id: undeploy-my-kibana
+      run: |-
+        cat <<EOT >> .body-content
+        ### Kibana pull request
+
+        ${{ env.PR }}
+
+        ### Further details
+
+        Caused by @${{ env.USER }} in https://github.com/${{ env.REPO }}/pull/${{ env.PR }}
+        EOT
+
+        gh issue \
+          create \
+          --label 'destroy-custom-kibana-serverless' \
+          --title "[Undeploy Kibana] ${{ env.REPO }}@pr-${{ env.PR }}" \
+          --body-file .body-content \
+          --repo elastic/observability-test-environments | tee .issue
+        echo "issue=$(cat .issue)" >> "$GITHUB_OUTPUT"
+
+        rm .issue .body-content || true
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR: ${{ inputs.pull-request }}
+        REPO: ${{ inputs.repository }}
+        USER: ${{ steps.gh_api_pr_author.outputs.result }}
+      shell: bash

--- a/oblt-cli/undeploy-my-kibana/action.yml
+++ b/oblt-cli/undeploy-my-kibana/action.yml
@@ -72,7 +72,7 @@ runs:
 
         ### Further details
 
-        Caused by @${{ env.PR_AUTHOR }} in https://github.com/${{ env.REPO }}/pull/${{ env.PR }}
+        Caused by @${{ env.PR_AUTHOR }} in https://github.com/${{ env.REPO }}/pull/${{ env.PR }} via this [GitHub workflow build](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})
         EOT
 
         gh issue \

--- a/oblt-cli/undeploy-my-kibana/action.yml
+++ b/oblt-cli/undeploy-my-kibana/action.yml
@@ -28,15 +28,7 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
       shell: bash
 
-    - uses: elastic/oblt-actions/github/is-member-of@v1
-      id: is_elastic_member
-      with:
-        github-user: ${{ steps.gh_api_pr_author.outputs.result }}
-        github-org: "elastic"
-        github-token: ${{ inputs.github-token }}
-
-    - if: contains(steps.is_elastic_member.outputs.result, 'true')
-      name: Create GitHub issue body
+    - name: Create GitHub issue body
       id: undeploy-my-kibana
       run: |-
         cat <<EOT >> .body-content

--- a/oblt-cli/undeploy-my-kibana/action.yml
+++ b/oblt-cli/undeploy-my-kibana/action.yml
@@ -8,8 +8,14 @@ inputs:
     description: 'The GitHub repository'
     default: ${{ github.repository }}
   github-token:
-    description: 'The GitHub access token.'
-    required: true
+    description: 'The GitHub Personal Access Token.'
+    required: false
+  github-app-id:
+    description: 'The GitHub App ID to generate the ephemeral token.'
+    required: false
+  github-app-private-key:
+    description: 'The GitHub App Private Key to generate the ephemeral token.'
+    required: false
 
 outputs:
   issue:
@@ -19,13 +25,41 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: gh_api_pr_author
-      name: Gather PR Owner
+
+    - if: ${{ (inputs.github-token == '' && inputs.github-app-id == '' && inputs.github-app-private-key == '') || (inputs.github-token != '' && inputs.github-app-id != '' && inputs.github-app-private-key != '') }}
+      name: Validate input parameters
+      run: echo "use either github-token or github-app-id and github-app-private-key" && exit 1
+      shell: bash
+
+    - name: Get token
+      if: ${{ inputs.github-token == '' }}
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ inputs.github-app-id }}
+        private_key: ${{ inputs.github-app-private-key }}
+        permissions: >-
+          {
+            "contents": "read",
+            "issues": "write"
+          }
+        repositories: >-
+          ["observability-test-environments"]
+
+    - if: ${{ inputs.github-token == '' }}
+      name: If ephemeral GitHub token app generated
+      run: echo "GH_TOKEN=${{ steps.get_token.outputs.token }}" >> "$GITHUB_ENV"
+      shell: bash
+
+    - if: ${{ inputs.github-token != '' }}
+      name: If GitHub token provided
+      run: echo "GH_TOKEN=${{ inputs.github-token }}" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Gather PR Owner
       run: |-
         PR_AUTHOR=$(gh pr view ${{ inputs.pull-request }} --repo ${{ inputs.repository }} --json author --jq .author.login)
-        echo "result=${PR_AUTHOR}" >> $GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        echo "PR_AUTHOR=${PR_AUTHOR}" >> $GITHUB_ENV
       shell: bash
 
     - name: Create GitHub issue body
@@ -38,7 +72,7 @@ runs:
 
         ### Further details
 
-        Caused by @${{ env.USER }} in https://github.com/${{ env.REPO }}/pull/${{ env.PR }}
+        Caused by @${{ env.PR_AUTHOR }} in https://github.com/${{ env.REPO }}/pull/${{ env.PR }}
         EOT
 
         gh issue \
@@ -51,8 +85,6 @@ runs:
 
         rm .issue .body-content || true
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
         PR: ${{ inputs.pull-request }}
         REPO: ${{ inputs.repository }}
-        USER: ${{ steps.gh_api_pr_author.outputs.result }}
       shell: bash


### PR DESCRIPTION
### What

An initial attempt to move away from a finer-grained token and use ephemeral tokens.

### Further details


It's difficult to migrate https://github.com/elastic/apm-pipeline-library/tree/main/.github/actions/undeploy-my-kibana to use the GH App ephemeral tokens.

It requires different permissions to access the members of a given org, so it can add an extra validation if the PR author is a member of Elastic.

I decided to remove that because it will require further complicated code, and the GitHub labels filtering in the workflows are good enough:
- https://github.com/elastic/kibana/blob/8d83a075f6228bb5a6e35a9bb4654fe29cee0cff/.github/workflows/undeploy-my-kibana.yml#L21