### PR TITLE
feat(deploy-my-kibana): use github secrets

### DIFF
--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -30,7 +30,7 @@ jobs:
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
           comment-url: https://github.com/elastic/oblt-actions/pull/59#issuecomment-2213186823
           comment-id: 2213186823
-          issue-url: https://api.github.com/repos/elastic/oblt-actions/issues/195219
+          issue-url: https://api.github.com/repos/elastic/oblt-actions/issues/59
           repository: 'elastic/oblt-actions'
 
   no-parameters:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          pull-request: '195219'
+          comment_url: https://github.com/elastic/kibana/pull/195219#issuecomment-2397814616
+          comment_id: 2397814616
+          issue_url: https://api.github.com/repos/elastic/kibana/issues/195219
           repository: 'elastic/kibana'
 
   no-parameters:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          comment-url: https://github.com/elastic/kibana/pull/195219#issuecomment-2397814616
-          comment-id: 2397814616
-          issue-url: https://api.github.com/repos/elastic/kibana/issues/195219
-          repository: 'elastic/kibana'
+          comment-url: https://github.com/elastic/oblt-actions/pull/59#issuecomment-2213186823
+          comment-id: 2213186823
+          issue-url: https://api.github.com/repos/elastic/oblt-actions/issues/195219
+          repository: 'elastic/oblt-actions'
 
   no-parameters:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          comment_url: https://github.com/elastic/kibana/pull/195219#issuecomment-2397814616
-          comment_id: 2397814616
-          issue_url: https://api.github.com/repos/elastic/kibana/issues/195219
+          comment-url: https://github.com/elastic/kibana/pull/195219#issuecomment-2397814616
+          comment-id: 2397814616
+          issue-url: https://api.github.com/repos/elastic/kibana/issues/195219
           repository: 'elastic/kibana'
 
   no-parameters:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -1,0 +1,69 @@
+name: test-deploy-my-kibana
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-deploy-my-kibana.yml'
+      - 'oblt-cli/deploy-my-kibana/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-deploy-my-kibana.yml'
+      - 'oblt-cli/deploy-my-kibana/**'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-my-kibana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./oblt-cli/deploy-my-kibana
+        with:
+          github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          pull-request: '195219'
+          repository: 'elastic/kibana'
+
+  no-parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./oblt-cli/deploy-my-kibana
+        id: validation
+        continue-on-error: true
+      - name: Assert is failure if no parameters
+        run: test "${{steps.validation.outcome}}" = "failure"
+
+  all-parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./oblt-cli/deploy-my-kibana
+        id: validation
+        continue-on-error: true
+        with:
+          github-app-id: "app"
+          github-app-private-key: "key"
+          github-token: "foo"
+      - name: Assert is failure if all parameters
+        run: test "${{steps.validation.outcome}}" = "failure"
+
+  test:
+    if: always()
+    needs:
+      - deploy-my-kibana
+      - no-parameters
+      - all-parameters
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   deploy-my-kibana:

--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          pull-request: '187489'
+          pull-request: '195219'
           repository: 'elastic/kibana'
 
   no-parameters:

--- a/oblt-cli/deploy-my-kibana/README.md
+++ b/oblt-cli/deploy-my-kibana/README.md
@@ -1,6 +1,8 @@
 # <!--name-->oblt-cli/deploy-my-kibana<!--/name-->
 
 [![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fdeploy-my-kibana+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-oblt-cli-deploy-my-kibana](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-deploy-my-kibana.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-deploy-my-kibana.yml)
+
 
 <!--description-->
 Run the deploy my Kibana PR.
@@ -8,15 +10,24 @@ Run the deploy my Kibana PR.
 
 ## Inputs
 <!--inputs-->
-| Name           | Description                                 | Required | Default                                 |
-|----------------|---------------------------------------------|----------|-----------------------------------------|
-| `comment-url`  | The GitHub Comment URL                      | `false`  | `${{ github.event.comment.html_url }}`  |
-| `comment-id`   | The GitHub Comment ID                       | `false`  | `${{ github.event.comment.id }}`        |
-| `github-token` | The GitHub access token.                    | `true`   | ` `                                     |
-| `issue-url`    | The GitHub Issue URL                        | `false`  | `${{ github.event.comment.issue_url }}` |
-| `repository`   | The GitHub repository                       | `false`  | `${{ github.repository }}`              |
-| `user`         | The GitHub user that triggered the workflow | `false`  | `${{ github.triggering_actor }}`        |
+| Name                     | Description                                                 | Required | Default                                 |
+|--------------------------|-------------------------------------------------------------|----------|-----------------------------------------|
+| `comment-url`            | The GitHub Comment URL                                      | `false`  | `${{ github.event.comment.html_url }}`  |
+| `comment-id`             | The GitHub Comment ID                                       | `false`  | `${{ github.event.comment.id }}`        |
+| `issue-url`              | The GitHub Issue URL                                        | `false`  | `${{ github.event.comment.issue_url }}` |
+| `repository`             | The GitHub repository                                       | `false`  | `${{ github.repository }}`              |
+| `user`                   | The GitHub user that triggered the workflow                 | `false`  | `${{ github.triggering_actor }}`        |
+| `github-token`           | The GitHub Personal Access Token.                           | `false`  | ` `                                     |
+| `github-app-id`          | The GitHub App ID to generate the ephemeral token.          | `false`  | ` `                                     |
+| `github-app-private-key` | The GitHub App Private Key to generate the ephemeral token. | `false`  | ` `                                     |
 <!--/inputs-->
+
+## Output
+<!--outputs-->
+| Name    | Description                                                   |
+|---------|---------------------------------------------------------------|
+| `issue` | The GitHub issue that has been created to destroy the cluster |
+<!--/outputs-->
 
 ## Usage
 <!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->

--- a/oblt-cli/deploy-my-kibana/README.md
+++ b/oblt-cli/deploy-my-kibana/README.md
@@ -1,0 +1,35 @@
+# <!--name-->oblt-cli/deploy-my-kibana<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fdeploy-my-kibana+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+
+<!--description-->
+Run the deploy my Kibana PR.
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name           | Description                                 | Required | Default                                 |
+|----------------|---------------------------------------------|----------|-----------------------------------------|
+| `comment-url`  | The GitHub Comment URL                      | `false`  | `${{ github.event.comment.html_url }}`  |
+| `comment-id`   | The GitHub Comment ID                       | `false`  | `${{ github.event.comment.id }}`        |
+| `github-token` | The GitHub access token.                    | `true`   | ` `                                     |
+| `issue-url`    | The GitHub Issue URL                        | `false`  | `${{ github.event.comment.issue_url }}` |
+| `repository`   | The GitHub repository                       | `false`  | `${{ github.repository }}`              |
+| `user`         | The GitHub user that triggered the workflow | `false`  | `${{ github.triggering_actor }}`        |
+<!--/inputs-->
+
+## Usage
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  deploy-my-kibana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/oblt-cli/deploy-my-kibana@v1
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+```
+<!--/usage-->

--- a/oblt-cli/deploy-my-kibana/README.md
+++ b/oblt-cli/deploy-my-kibana/README.md
@@ -38,6 +38,11 @@ on:
 jobs:
   deploy-my-kibana:
     runs-on: ubuntu-latest
+    permissions:
+      # if you listen for PRs, use this to use some comment reactions
+      pull-requests: write
+      # if you listen for issues, use this to use some comment reactions
+      issues: write
     steps:
       - uses: elastic/oblt-actions/oblt-cli/deploy-my-kibana@v1
         with:

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -52,8 +52,8 @@ runs:
       with:
         app_id: ${{ inputs.github-app-id }}
         private_key: ${{ inputs.github-app-private-key }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ inputs.github-app-id }}
+        installation_retrieval_mode: organization
+        installation_retrieval_payload: elastic
         permissions: >-
           {
             "contents": "read",

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -55,7 +55,7 @@ runs:
         permissions: >-
           {
             "contents": "read",
-            "pull_requests": "write",
+            "issues": "write",
             "members": "read"
           }
         # As long as we use members: read we cannot use the repositories input.

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -52,6 +52,7 @@ runs:
       with:
         app_id: ${{ inputs.github-app-id }}
         private_key: ${{ inputs.github-app-private-key }}
+        installation_retrieval_mode: id
         permissions: >-
           {
             "contents": "read",

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -34,12 +34,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # TODO: need to be implemented
-    # - uses: elastic/oblt-actions/github/comment-reaction@v1
-    #   with:
-    #     repository: ${{ inputs.repository }}
-    #     comment-id: ${{ inputs.comment-id }}
-    #     github-token: ${{ inputs.github-token }}
+    - uses: elastic/oblt-actions/github/comment-reaction@v1
+      with:
+        repository: ${{ inputs.repository }}
+        comment-id: ${{ inputs.comment-id }}
+        github-token: ${{ github.token }}
 
     - if: ${{ (inputs.github-token == '' && inputs.github-app-id == '' && inputs.github-app-private-key == '') || (inputs.github-token != '' && inputs.github-app-id != '' && inputs.github-app-private-key != '') }}
       name: Validate input parameters
@@ -56,7 +55,7 @@ runs:
         permissions: >-
           {
             "contents": "read",
-            "issues": "write",
+            "pull_requests": "write",
             "members": "read"
           }
         # As long as we use members: read we cannot use the repositories input.
@@ -129,12 +128,11 @@ runs:
         echo "issue=$(cat .issue)" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    # TODO: need to be implemented
-    # - name: Notify with a reaction if a non-elastician comment
-    #   uses: elastic/oblt-actions/github/comment-reaction@v1
-    #   if: contains(steps.is_elastic_member.outputs.result, 'false')
-    #   with:
-    #     repository: ${{ inputs.repository }}
-    #     comment-id: ${{ inputs.comment-id }}
-    #     emoji: '-1'
-    #     github-token: ${{ inputs.github-token }}
+    - name: Notify with a reaction if a non-elastician comment
+      uses: elastic/oblt-actions/github/comment-reaction@v1
+      if: contains(steps.is_elastic_member.outputs.result, 'false')
+      with:
+        repository: ${{ inputs.repository }}
+        comment-id: ${{ inputs.comment-id }}
+        emoji: '-1'
+        github-token: ${{ github.token }}

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -1,0 +1,105 @@
+name: 'oblt-cli/deploy-my-kibana'
+description: 'Run the deploy my Kibana PR.'
+inputs:
+  comment-url:
+    description: 'The GitHub Comment URL'
+    default: ${{ github.event.comment.html_url }}
+  comment-id:
+    description: 'The GitHub Comment ID'
+    default: ${{ github.event.comment.id }}
+  github-token:
+    description: 'The GitHub access token.'
+    required: true
+  issue-url:
+    description: 'The GitHub Issue URL'
+    default: ${{ github.event.comment.issue_url }}
+  repository:
+    description: 'The GitHub repository'
+    default: ${{ github.repository }}
+  user:
+    description: 'The GitHub user that triggered the workflow'
+    default: ${{ github.triggering_actor }}
+runs:
+  using: "composite"
+  steps:
+    - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
+      with:
+        repository: ${{ inputs.repository }}
+        commentId: ${{ inputs.comment-id }}
+        token: ${{ inputs.github-token }}
+
+    - name: Is an Elastician comment?
+      id: is_elastic_member
+      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+      with:
+        username: ${{ inputs.user }}
+        token: ${{ inputs.github-token }}
+
+    - name: Get cluster given the target branch (either edge-lite or release)
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: |-
+        PR=$(basename ${{ inputs.issue-url }})
+        echo "PR=${PR}" >> $GITHUB_ENV
+
+        # issue_comment does not contain any references to github.base_ref
+        TARGET_BRANCH=$(gh pr view ${PR} --repo ${{ inputs.repository }} --json baseRefName --jq .baseRefName)
+
+        if [ "${TARGET_BRANCH}" == 'main' ] ; then
+          echo "CLUSTER=edge-lite-oblt" >> $GITHUB_ENV
+        else
+          echo "CLUSTER=release-oblt" >> $GITHUB_ENV
+        fi
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+
+    - name: Create github issue body
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: |-
+        cat <<EOT >> .body-content
+        ### From cluster
+
+        ${{ env.CLUSTER }}
+
+        ### Kibana branch
+
+        pr/${{ env.PR }}
+
+        ### Custom prefix (Optional)
+
+        _No response_
+
+        ### Oblt-cli user (Optional)
+
+        deploykibana
+
+        ### Further details
+
+        Caused by @${{ inputs.user }} in ${{ inputs.comment-url }}
+        EOT
+      shell: bash
+
+    - name: Create github issue for the deploy-my-kibana
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: |
+        gh issue \
+          create \
+          --label 'deploy-custom-kibana' \
+          --title "[Deploy Kibana] for user ${{ inputs.user }} with PR kibana@pr-${{ env.PR }} on cluster ${{ env.CLUSTER }}" \
+          --assignee ${{ inputs.user }} \
+          --body-file .body-content \
+          --repo elastic/observability-test-environments | tee .issue
+        echo "ISSUE=$(cat .issue)" >> $GITHUB_ENV
+        echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      shell: bash
+
+    - name: Notify with a reaction if a non-elastician comment
+      uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
+      if: contains(steps.is_elastic_member.outputs.result, 'false')
+      with:
+        repository: ${{ inputs.repository }}
+        commentId: ${{ inputs.comment-id }}
+        emoji: '-1'
+        token: ${{ inputs.github-token }}

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -53,6 +53,7 @@ runs:
         app_id: ${{ inputs.github-app-id }}
         private_key: ${{ inputs.github-app-private-key }}
         installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ inputs.github-app-id }}
         permissions: >-
           {
             "contents": "read",

--- a/oblt-cli/deploy-my-kibana/action.yml
+++ b/oblt-cli/deploy-my-kibana/action.yml
@@ -7,9 +7,6 @@ inputs:
   comment-id:
     description: 'The GitHub Comment ID'
     default: ${{ github.event.comment.id }}
-  github-token:
-    description: 'The GitHub access token.'
-    required: true
   issue-url:
     description: 'The GitHub Issue URL'
     default: ${{ github.event.comment.issue_url }}
@@ -19,21 +16,67 @@ inputs:
   user:
     description: 'The GitHub user that triggered the workflow'
     default: ${{ github.triggering_actor }}
+  github-token:
+    description: 'The GitHub Personal Access Token.'
+    required: false
+  github-app-id:
+    description: 'The GitHub App ID to generate the ephemeral token.'
+    required: false
+  github-app-private-key:
+    description: 'The GitHub App Private Key to generate the ephemeral token.'
+    required: false
+
+outputs:
+  issue:
+    description: 'The GitHub issue that has been created to destroy the cluster'
+    value: ${{ steps.deploy-my-kibana.outputs.issue }}
+
 runs:
   using: "composite"
   steps:
-    - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
-      with:
-        repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.comment-id }}
-        token: ${{ inputs.github-token }}
+    # TODO: need to be implemented
+    # - uses: elastic/oblt-actions/github/comment-reaction@v1
+    #   with:
+    #     repository: ${{ inputs.repository }}
+    #     comment-id: ${{ inputs.comment-id }}
+    #     github-token: ${{ inputs.github-token }}
 
-    - name: Is an Elastician comment?
-      id: is_elastic_member
-      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+    - if: ${{ (inputs.github-token == '' && inputs.github-app-id == '' && inputs.github-app-private-key == '') || (inputs.github-token != '' && inputs.github-app-id != '' && inputs.github-app-private-key != '') }}
+      name: Validate input parameters
+      run: echo "use either github-token or github-app-id and github-app-private-key" && exit 1
+      shell: bash
+
+    - name: Get token
+      if: ${{ inputs.github-token == '' }}
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
       with:
-        username: ${{ inputs.user }}
-        token: ${{ inputs.github-token }}
+        app_id: ${{ inputs.github-app-id }}
+        private_key: ${{ inputs.github-app-private-key }}
+        permissions: >-
+          {
+            "contents": "read",
+            "issues": "write",
+            "members": "read"
+          }
+        # As long as we use members: read we cannot use the repositories input.
+
+    - if: ${{ inputs.github-token == '' }}
+      name: If ephemeral GitHub token app generated
+      run: echo "GH_TOKEN=${{ steps.get_token.outputs.token }}" >> "$GITHUB_ENV"
+      shell: bash
+
+    - if: ${{ inputs.github-token != '' }}
+      name: If GitHub token provided
+      run: echo "GH_TOKEN=${{ inputs.github-token }}" >> "$GITHUB_ENV"
+      shell: bash
+
+    - uses: elastic/oblt-actions/github/is-member-of@v1
+      id: is_elastic_member
+      with:
+        github-user: ${{ inputs.user }}
+        github-org: "elastic"
+        github-token: ${{ env.GH_TOKEN }}
 
     - name: Get cluster given the target branch (either edge-lite or release)
       if: contains(steps.is_elastic_member.outputs.result, 'true')
@@ -50,11 +93,10 @@ runs:
           echo "CLUSTER=release-oblt" >> $GITHUB_ENV
         fi
       shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
 
-    - name: Create github issue body
+    - name: Create GitHub issue
       if: contains(steps.is_elastic_member.outputs.result, 'true')
+      id: deploy-my-kibana
       run: |-
         cat <<EOT >> .body-content
         ### From cluster
@@ -75,13 +117,8 @@ runs:
 
         ### Further details
 
-        Caused by @${{ inputs.user }} in ${{ inputs.comment-url }}
+        Caused by @${{ inputs.user }} in ${{ inputs.comment-url }} via this [GitHub workflow build](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})
         EOT
-      shell: bash
-
-    - name: Create github issue for the deploy-my-kibana
-      if: contains(steps.is_elastic_member.outputs.result, 'true')
-      run: |
         gh issue \
           create \
           --label 'deploy-custom-kibana' \
@@ -89,17 +126,15 @@ runs:
           --assignee ${{ inputs.user }} \
           --body-file .body-content \
           --repo elastic/observability-test-environments | tee .issue
-        echo "ISSUE=$(cat .issue)" >> $GITHUB_ENV
-        echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        echo "issue=$(cat .issue)" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: Notify with a reaction if a non-elastician comment
-      uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
-      if: contains(steps.is_elastic_member.outputs.result, 'false')
-      with:
-        repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.comment-id }}
-        emoji: '-1'
-        token: ${{ inputs.github-token }}
+    # TODO: need to be implemented
+    # - name: Notify with a reaction if a non-elastician comment
+    #   uses: elastic/oblt-actions/github/comment-reaction@v1
+    #   if: contains(steps.is_elastic_member.outputs.result, 'false')
+    #   with:
+    #     repository: ${{ inputs.repository }}
+    #     comment-id: ${{ inputs.comment-id }}
+    #     emoji: '-1'
+    #     github-token: ${{ inputs.github-token }}

--- a/oblt-cli/undeploy-my-kibana/README.md
+++ b/oblt-cli/undeploy-my-kibana/README.md
@@ -1,7 +1,7 @@
 # <!--name-->oblt-cli/undeploy-my-kibana<!--/name-->
 
 [![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%2Fundeploy-my-kibana+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
-[![test-oblt-cli-cluster-name-validation](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml)
+[![test-oblt-cli-undeploy-my-kibana](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-undeploy-my-kibana.yml)
 
 <!--description-->
 Undeploy my kibana given the Pull Request


### PR DESCRIPTION
### What

Replace https://github.com/elastic/apm-pipeline-library/tree/main/.github/actions/deploy-my-kibana with GitHub secrets and support only for no serverless.


### Issues

Requires https://github.com/elastic/oblt-actions/pull/143


### Test 

See https://github.com/elastic/oblt-actions/pull/59#issuecomment-2213186823

<img width="377" alt="image" src="https://github.com/user-attachments/assets/2a2e34ff-f0bd-49b1-901f-a0a570abefe8">


and a link to the GH private repository can be seen in this PR

<img width="875" alt="image" src="https://github.com/user-attachments/assets/36e29b3f-7874-4f8f-b9f5-a7afa1c4adf3">
