### PR TITLE
docs: rename parameter in example

### DIFF
--- a/oblt-cli/run/README.md
+++ b/oblt-cli/run/README.md
@@ -27,6 +27,6 @@ jobs:
       - uses: elastic/oblt-actions/oblt-cli/run@v1
         with:
           command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix mycustomcluster'
-          token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
 ```
 <!--/usage-->


### PR DESCRIPTION
The parameter is `github-token` instead of `token`