### PR TITLE
github-actions: support manual runs and merge-queue

### DIFF
--- a/.github/workflows/no-test.yml
+++ b/.github/workflows/no-test.yml
@@ -1,6 +1,8 @@
 name: no-test
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,8 @@
 name: pre-commit
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
   push:
     branches: [main]

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,6 +1,8 @@
 name: required-labels
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -1,6 +1,8 @@
 name: test-aws-auth
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     paths:
       - 'aws-auth/**'

--- a/.github/workflows/test-buildkite-download-artifact.yml
+++ b/.github/workflows/test-buildkite-download-artifact.yml
@@ -1,6 +1,7 @@
 name: test-buildkite-download-artifact
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   push:
     paths:

--- a/.github/workflows/test-buildkite-run.yml
+++ b/.github/workflows/test-buildkite-run.yml
@@ -1,6 +1,7 @@
 name: test-buildkite-run
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   push:
     paths:

--- a/.github/workflows/test-check-dependent-jobs.yml
+++ b/.github/workflows/test-check-dependent-jobs.yml
@@ -1,6 +1,8 @@
 name: test-check-dependent-jobs
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-elastic-active-branches.yml
+++ b/.github/workflows/test-elastic-active-branches.yml
@@ -1,6 +1,8 @@
 name: test-elastic-active-branches
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-git-setup.yml
+++ b/.github/workflows/test-git-setup.yml
@@ -1,6 +1,8 @@
 name: test-git-setup
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-github-comment-reaction.yml
+++ b/.github/workflows/test-github-comment-reaction.yml
@@ -1,6 +1,8 @@
 name: test-github-comment-reaction
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   push:
     paths:
       - '.github/workflows/test-github-comment-reaction.yml'

--- a/.github/workflows/test-github-is-member-of.yml
+++ b/.github/workflows/test-github-is-member-of.yml
@@ -1,6 +1,7 @@
 name: test-github-is-member-of
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/test-github-is-pr-author-member-of.yml
+++ b/.github/workflows/test-github-is-pr-author-member-of.yml
@@ -1,6 +1,7 @@
 name: test-github-is-pr-author-member-of
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/test-google-auth.yml
+++ b/.github/workflows/test-google-auth.yml
@@ -1,6 +1,8 @@
 name: test-google-auth
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-kibana-docker-image.yml
+++ b/.github/workflows/test-kibana-docker-image.yml
@@ -1,6 +1,7 @@
 name: test-kibana-docker-image
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   push:
     paths:

--- a/.github/workflows/test-maven-await-artifact.yml
+++ b/.github/workflows/test-maven-await-artifact.yml
@@ -1,6 +1,8 @@
 name: test-maven-await-artifact
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     paths:
       - 'maven/await-artifact/**'

--- a/.github/workflows/test-oblt-cli-cluster-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-custom.yml
@@ -1,6 +1,7 @@
 name: test-oblt-cli-cluster-create-custom
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
@@ -1,6 +1,7 @@
 name: test-oblt-cli-cluster-create-serverless
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/test-oblt-cli-cluster-credentials.yml
+++ b/.github/workflows/test-oblt-cli-cluster-credentials.yml
@@ -1,6 +1,7 @@
 name: test-oblt-cli-cluster-credentials
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   push:
     paths:

--- a/.github/workflows/test-oblt-cli-cluster-name-validation.yml
+++ b/.github/workflows/test-oblt-cli-cluster-name-validation.yml
@@ -1,6 +1,8 @@
 name: test-oblt-cli-cluster-name-validation
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-oblt-cli-create-ccs.yml
+++ b/.github/workflows/test-oblt-cli-create-ccs.yml
@@ -1,6 +1,7 @@
 name: test-oblt-cli-cluster-create-ccs
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -1,6 +1,8 @@
 name: test-deploy-my-kibana
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-oblt-cli-run.yml
+++ b/.github/workflows/test-oblt-cli-run.yml
@@ -1,6 +1,8 @@
 name: test-oblt-cli-run
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-oblt-cli-setup.yml
+++ b/.github/workflows/test-oblt-cli-setup.yml
@@ -1,6 +1,7 @@
 name: test-oblt-cli-setup
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   push:
     paths:

--- a/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-undeploy-my-kibana.yml
@@ -1,6 +1,8 @@
 name: test-undeploy-my-kibana
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-slack-notify-result.yml
+++ b/.github/workflows/test-slack-notify-result.yml
@@ -1,6 +1,8 @@
 name: test-slack-notify-result
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -1,6 +1,8 @@
 name: test-slack-send
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-updatecli-run.yml
+++ b/.github/workflows/test-updatecli-run.yml
@@ -1,6 +1,8 @@
 name: test-updatecli-run
 
 on:
+  merge_group: ~
+  workflow_dispatch: ~
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-version-framework.yml
+++ b/.github/workflows/test-version-framework.yml
@@ -1,6 +1,7 @@
 name: test-version-framework
 
 on:
+  merge_group: ~
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
Support for the merge-queue

We need to use an upstream branch when touching test workflows that require secrets