### PR TITLE
Fixed broken await-artifact action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .vscode/
 node_modules/
+.DS_Store

--- a/maven/await-artifact/action.yml
+++ b/maven/await-artifact/action.yml
@@ -28,7 +28,7 @@ runs:
       if: ${{ inputs.sonatype-central == 'true' }}
       shell: bash
       run: |
-        TIME=30
+        WAIT_SECONDS=30
         full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${VERSION}"
         until curl -fs -I -L "${full_url}" > /dev/null
         do
@@ -44,7 +44,7 @@ runs:
       if: ${{ inputs.maven-central == 'true' }}
       shell: bash
       run: |
-        TIME=30
+        WAIT_SECONDS=30
         GROUP_FOLDER="${GROUP_ID//.//}"
         full_url="https://repo.maven.apache.org/maven2/${GROUP_FOLDER}/${ARTIFACT_ID}/${VERSION}"
         until curl -fs -I -L "${full_url}" > /dev/null


### PR DESCRIPTION
While attempting to do a release, we discovered that apparently the await-artifact action is currently broken:

```
Artifact co.elastic.apm:elastic-apm-agent:1.52.1 not found on proxy maven central. Sleeping  seconds, retrying afterwards
sleep: invalid time interval ‘s’
Try 'sleep --help' for more information.
```