### PR TITLE
revert: use v2.68.0

### DIFF
--- a/updatecli/install/action.yml
+++ b/updatecli/install/action.yml
@@ -6,4 +6,4 @@ runs:
   using: composite
   steps:
     - name: Install Updatecli in the runner
-      uses: updatecli/updatecli-action@704a64517239e0993c5e3bf6749a063b8f950d9f # v2.70.0
+      uses: updatecli/updatecli-action@92a13b95c2cd9f1c6742c965509203c6a5635ed7 # v2.68.0


### PR DESCRIPTION
The new version contains a breaking change for using dependsOn, source is not anymore the first task to run

> Sources were always executed before conditions and then targets.


https://github.com/updatecli/updatecli/releases/tag/v0.86.0