### PR TITLE
ci: avoid running often the deploy-my-kibana

### DIFF
--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/test-deploy-my-kibana.yml'
+      - '.github/workflows/test-oblt-cli-deploy-my-kibana.yml'
       - 'oblt-cli/deploy-my-kibana/**'
 
 permissions:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -1,6 +1,7 @@
 name: test-deploy-my-kibana
 
 on:
+  merge_group: ~
   workflow_dispatch: ~
   pull_request:
     branches:
@@ -20,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./oblt-cli/deploy-my-kibana
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           github-app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           github-app-private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
@@ -33,9 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./oblt-cli/deploy-my-kibana
+        if: ${{ github.event_name != 'merge_group' }}
         id: validation
         continue-on-error: true
       - name: Assert is failure if no parameters
+        if: ${{ github.event_name != 'merge_group' }}
         run: test "${{steps.validation.outcome}}" = "failure"
 
   all-parameters:
@@ -43,6 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./oblt-cli/deploy-my-kibana
+        if: ${{ github.event_name != 'merge_group' }}
         id: validation
         continue-on-error: true
         with:
@@ -50,6 +55,7 @@ jobs:
           github-app-private-key: "key"
           github-token: "foo"
       - name: Assert is failure if all parameters
+        if: ${{ github.event_name != 'merge_group' }}
         run: test "${{steps.validation.outcome}}" = "failure"
 
   test:

--- a/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
+++ b/.github/workflows/test-oblt-cli-deploy-my-kibana.yml
@@ -1,15 +1,8 @@
 name: test-deploy-my-kibana
 
 on:
-  merge_group: ~
   workflow_dispatch: ~
   pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/test-deploy-my-kibana.yml'
-      - 'oblt-cli/deploy-my-kibana/**'
-  push:
     branches:
       - main
     paths:


### PR DESCRIPTION
This should help with reducing the build times and creating leftovers for the `oblt-test-env`.