### PR TITLE
aws/auth: Pass outputs from upstream action to this action

### DIFF
--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -23,14 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./aws/auth
-        id: aws-auth
-        continue-on-error: true
-        with:
-          aws-region: 'us-west-2'
-      - name: assert generated role arn
-        run: |
-          workflow_filename=$(echo "${GITHUB_WORKFLOW_REF}" | awk -F'/' '{ print $5 }' | awk -F'@' '{ print $1 }')
-          hash=$(echo -n "${GITHUB_REPOSITORY}/${workflow_filename}" | sha256sum | awk '{print $1}' | cut -c -55)
-          arn="arn:aws:iam::697149045717:role/gha-${hash}-role"
-
-          test "${arn}" = "${{ steps.aws-auth.outputs.role-arn }}"
+      - run: aws sts get-caller-identity

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./aws/auth
         id: auth
-        with:
-          output-credentials: true
       - run: aws sts get-caller-identity
 
   test:

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -24,6 +24,7 @@ jobs:
       aws-access-key-id: ${{ steps.auth.outputs.aws-access-key-id }}
       aws-secret-access-key: ${{ steps.auth.outputs.aws-secret-access-key }}
       aws-session-token: ${{ steps.auth.outputs.aws-session-token }}
+      role-arn: ${{ steps.auth.outputs.role-arn }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
+          role-to-assume: ${{ needs.create-credentials.outputs.role-arn }}
           aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
           aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
           aws-session-token: ${{ needs.create-credentials.outputs.aws-session-token }}

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -44,5 +44,5 @@ jobs:
           role-to-assume: ${{ needs.create-credentials.outputs.role-arn }}
           aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
           aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
-          aws-session-token: ${{ needs.create-credentials.outputs.aws-session-token }}
+#          aws-session-token: ${{ needs.create-credentials.outputs.aws-session-token }}
       - run: aws sts get-caller-identity

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -19,9 +19,24 @@ permissions:
   id-token: write
 
 jobs:
-  test:
+  create-credentials:
+    outputs:
+      aws-access-key-id: ${{ steps.auth.outputs.aws-access-key-id }}
+      aws-secret-access-key: ${{ steps.auth.outputs.aws-secret-access-key }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./aws/auth
+        id: auth
+      - run: aws sts get-caller-identity
+
+  test:
+    needs: create-credentials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
+          aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
       - run: aws sts get-caller-identity

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./aws/auth
         id: auth
+        with:
+          output-credentials: true
       - run: aws sts get-caller-identity
 
   test:

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       aws-access-key-id: ${{ steps.auth.outputs.aws-access-key-id }}
       aws-secret-access-key: ${{ steps.auth.outputs.aws-secret-access-key }}
+      aws-session-token: ${{ steps.auth.outputs.aws-session-token }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,4 +40,5 @@ jobs:
           aws-region: us-east-1
           aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
           aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
+          aws-session-token: ${{ needs.create-credentials.outputs.aws-session-token }}
       - run: aws sts get-caller-identity

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -44,5 +44,4 @@ jobs:
           role-to-assume: ${{ needs.create-credentials.outputs.role-arn }}
           aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
           aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
-#          aws-session-token: ${{ needs.create-credentials.outputs.aws-session-token }}
       - run: aws sts get-caller-identity

--- a/aws/auth/README.md
+++ b/aws/auth/README.md
@@ -24,6 +24,7 @@ AWS role ARN we use for Elastic Observability repositories.
 | Name                    | Description               |
 |-------------------------|---------------------------|
 | `role-arn`              | The generated role ARN    |
+| `aws-account-id`        | The AWS account ID        |
 | `aws-access-key-id`     | The AWS access key ID     |
 | `aws-secret-access-key` | The AWS secret access key |
 | `aws-session-token`     | The AWS session token     |

--- a/aws/auth/README.md
+++ b/aws/auth/README.md
@@ -17,7 +17,6 @@ AWS role ARN we use for Elastic Observability repositories.
 | `aws-account-id`        | The AWS account ID                                                                                                               | `false`  | `697149045717` |
 | `aws-region`            | The AWS region, e.g. us-east-1                                                                                                   | `false`  | `us-east-1`    |
 | `role-duration-seconds` | The assumed role duration in seconds, if assuming a role. Defaults to 1 hour, but cannot exceed the maximum defined by the role. | `false`  | `3600`         |
-| `output-credentials`    | Whether to output the AWS credentials                                                                                            | `false`  | `false`        |
 <!--/inputs-->
 
 ## Outputs

--- a/aws/auth/README.md
+++ b/aws/auth/README.md
@@ -21,9 +21,12 @@ AWS role ARN we use for Elastic Observability repositories.
 
 ## Outputs
 <!--outputs-->
-| Name       | Description            |
-|------------|------------------------|
-| `role-arn` | The generated role ARN |
+| Name                    | Description               |
+|-------------------------|---------------------------|
+| `role-arn`              | The generated role ARN    |
+| `aws-access-key-id`     | The AWS access key ID     |
+| `aws-secret-access-key` | The AWS secret access key |
+| `aws-session-token`     | The AWS session token     |
 <!--/outputs-->
 
 ## Usage

--- a/aws/auth/README.md
+++ b/aws/auth/README.md
@@ -17,6 +17,7 @@ AWS role ARN we use for Elastic Observability repositories.
 | `aws-account-id`        | The AWS account ID                                                                                                               | `false`  | `697149045717` |
 | `aws-region`            | The AWS region, e.g. us-east-1                                                                                                   | `false`  | `us-east-1`    |
 | `role-duration-seconds` | The assumed role duration in seconds, if assuming a role. Defaults to 1 hour, but cannot exceed the maximum defined by the role. | `false`  | `3600`         |
+| `output-credentials`    | Whether to output the AWS credentials                                                                                            | `false`  | `false`        |
 <!--/inputs-->
 
 ## Outputs

--- a/aws/auth/action.yml
+++ b/aws/auth/action.yml
@@ -18,10 +18,6 @@ inputs:
     description: 'The assumed role duration in seconds, if assuming a role. Defaults to 1 hour, but cannot exceed the maximum defined by the role.'
     required: false
     default: '3600'
-  output-credentials:
-    description: 'Whether to output the AWS credentials'
-    required: false
-    default: 'false'
 
 outputs:
   role-arn:
@@ -74,4 +70,4 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ steps.generate-role-arn.outputs.role-arn }}
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
-        output-credentials: ${{ inputs.output-credentials }}
+        output-credentials: true

--- a/aws/auth/action.yml
+++ b/aws/auth/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'The assumed role duration in seconds, if assuming a role. Defaults to 1 hour, but cannot exceed the maximum defined by the role.'
     required: false
     default: '3600'
+  output-credentials:
+    description: 'Whether to output the AWS credentials'
+    required: false
+    default: 'false'
 
 outputs:
   role-arn:
@@ -70,3 +74,4 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ steps.generate-role-arn.outputs.role-arn }}
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        output-credentials: ${{ inputs.output-credentials }}

--- a/aws/auth/action.yml
+++ b/aws/auth/action.yml
@@ -23,6 +23,9 @@ outputs:
   role-arn:
     description: 'The generated role ARN'
     value: ${{ steps.generate-role-arn.outputs.role-arn }}
+  aws-account-id:
+    description: 'The AWS account ID'
+    value: ${{ inputs.aws-account-id }}
   aws-access-key-id:
     description: 'The AWS access key ID'
     value: ${{ steps.configure-aws-credentials.outputs.aws-access-key-id }}

--- a/aws/auth/action.yml
+++ b/aws/auth/action.yml
@@ -23,6 +23,15 @@ outputs:
   role-arn:
     description: 'The generated role ARN'
     value: ${{ steps.generate-role-arn.outputs.role-arn }}
+  aws-access-key-id:
+    description: 'The AWS access key ID'
+    value: ${{ steps.configure-aws-credentials.outputs.aws-access-key-id }}
+  aws-secret-access-key:
+    description: 'The AWS secret access key'
+    value: ${{ steps.configure-aws-credentials.outputs.aws-secret-access-key }}
+  aws-session-token:
+    description: 'The AWS session token'
+    value: ${{ steps.configure-aws-credentials.outputs.aws-session-token }}
 
 runs:
   using: composite
@@ -52,6 +61,7 @@ runs:
             f.write(f"role-arn={role_arn}")
 
     - name: Configure AWS Credentials
+      id: configure-aws-credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Details

This will allow us to set up OIDC in a non-invasive way.

## Use Case

We have a complex workflow using reusable workflows, which uses multiple AWS credentials.

This way, we can pass the temporary credentials to the reusable workflow without changing the logic.