### PR TITLE
fix: slack send with multiline and special characters

### DIFF
--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: ./slack/send
         id: slack-multi
         with:
-          bot-token: ${{ env.SLACK_BOT_TOKEN }}
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#observablt-bots"
           message: |
             :warning: I couldn't find a person for `foo` in the <${{ github.event.repository.html_url }}/blob/master/.github/config.json|config.json file>.

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -55,4 +55,6 @@ jobs:
             :warning: I couldn't find a person for `foo` in the <${{ github.event.repository.html_url }}/blob/master/.github/config.json|config.json file>.
             Make sure to update the `config.json` file or the schedule for `bar`!
 
+            Test some characters: & and * and < > \n \r
+
             Failed to assign <${{ github.event.repository.html_url }}|SDH #my-issue>.

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -39,8 +39,19 @@ jobs:
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#observablt-bots"
-          message: "Run soemthing else"
+          message: "Run something else"
           thread-timestamp: ${{ steps.slack-send.outputs.thread-timestamp || '' }}
 
       - name: validate thread-timestamp
         run: test -n "${{ steps.slack-reply.outputs.thread-timestamp }}"
+
+      - uses: ./slack/send
+        id: slack-multi
+        with:
+          bot-token: ${{ env.SLACK_BOT_TOKEN }}
+          channel-id: "#observablt-bots"
+          message: |
+            :warning: I couldn't find a person for `foo` in the <${{ github.event.repository.html_url }}/blob/master/.github/config.json|config.json file>.
+            Make sure to update the `config.json` file or the schedule for `bar`!
+
+            Failed to assign <${{ github.event.issue.html_url }}|SDH #${{ github.event.issue.number }}>.

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -50,8 +50,9 @@ jobs:
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#observablt-bots"
+          thread-timestamp: ${{ steps.slack-send.outputs.thread-timestamp || '' }}
           message: |
             :warning: I couldn't find a person for `foo` in the <${{ github.event.repository.html_url }}/blob/master/.github/config.json|config.json file>.
             Make sure to update the `config.json` file or the schedule for `bar`!
 
-            Failed to assign <${{ github.event.issue.html_url }}|SDH #${{ github.event.issue.number }}>.
+            Failed to assign <${{ github.event.repository.html_url }}|SDH #my-issue>.

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -56,7 +56,7 @@ runs:
           raise Exception("message must be set.")
 
         # Escape special characters for GitHub Actions output
-        message = message.replace('%', '%25').replace('\n', '%0A').replace('\r', '%0D')
+        message = message.replace('\n', '\\n').replace('\r', '\\r')
 
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("message={}".format(message))

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -55,6 +55,9 @@ runs:
         else:
           raise Exception("message must be set.")
 
+        # Escape special characters for GitHub Actions output
+        message = message.replace('%', '%25').replace('\n', '%0A').replace('\r', '%0D')
+
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("message={}".format(message))
 

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -71,9 +71,9 @@ runs:
           unfurl_media: false
           channel: "${{ inputs.channel-id }}"
           thread_ts: "${{ inputs.thread-timestamp }}"
-          text: ${{ steps.prepare.outputs.message }}
+          text: "${{ steps.prepare.outputs.message }}"
           blocks:
             - type: "section"
               text:
                 type: mrkdwn
-                text: ${{ steps.prepare.outputs.message }}
+                text: "${{ steps.prepare.outputs.message }}"


### PR DESCRIPTION
A regression when moving from `1.x` to `2.x` in https://github.com/elastic/oblt-actions/pull/164

Fixes issues when parsing the markdown:

<img width="588" alt="image" src="https://github.com/user-attachments/assets/98b25329-ba2f-46ca-a71b-ba5a6d7d702d">


### Details

I added a more comprehensive e2e test set to validate things work for more sophisticated slack notifications.

### Tests

See 

<img width="532" alt="image" src="https://github.com/user-attachments/assets/b73d41b5-c066-424c-8905-083cb03e95b5">



