### PR TITLE
Remove invalid test again

### DIFF
--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: ./aws/auth
         with:
           aws-region: us-east-1
       - run: aws sts get-caller-identity

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -22,6 +22,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./aws/auth
         with:
           aws-region: us-east-1

--- a/.github/workflows/test-aws-auth.yml
+++ b/.github/workflows/test-aws-auth.yml
@@ -19,27 +19,10 @@ permissions:
   id-token: write
 
 jobs:
-  create-credentials:
-    outputs:
-      aws-access-key-id: ${{ steps.auth.outputs.aws-access-key-id }}
-      aws-secret-access-key: ${{ steps.auth.outputs.aws-secret-access-key }}
-      aws-session-token: ${{ steps.auth.outputs.aws-session-token }}
-      role-arn: ${{ steps.auth.outputs.role-arn }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./aws/auth
-        id: auth
-      - run: aws sts get-caller-identity
-
   test:
-    needs: create-credentials
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-to-assume: ${{ needs.create-credentials.outputs.role-arn }}
-          aws-access-key-id: ${{ needs.create-credentials.outputs.aws-access-key-id }}
-          aws-secret-access-key: ${{ needs.create-credentials.outputs.aws-secret-access-key }}
       - run: aws sts get-caller-identity


### PR DESCRIPTION
## Context

Passing secrets https://github.com/elastic/oblt-actions/actions/runs/12083758738 from one job to another job doesn't 
work. (Passing it from one step to another should work though.)

<img width="562" alt="image" src="https://github.com/user-attachments/assets/ffebf74d-1cc1-41e5-b1ae-00cd7aa80c2f">

For some reason, the dependent job was able to authenticate with empty aws-access-key-id and empty aws-secret-access-key. Not sure how it works though.

## Changes

This will remove the secrets passing attempt in the test to avoid confusion or copypasta in the future.

