### PR TITLE
fix: sanitise slack message

### DIFF
--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -66,7 +66,7 @@ jobs:
           channel-id: "#observablt-bots"
           thread-timestamp: ${{ steps.slack-send.outputs.thread-timestamp || '' }}
           message: |
-            :wave: <@U03HGTRTLD6>!
+            :wave: !
             I have assigned you the following SDH, as to my knowledge you are currently on duty for `area::observability-rac`:
 
             *`urgency:48h` <https://github.com/elastic/sdh-kibana/issues/5098|#5098 - Adding the field "system.filesystem.free" to the output of an alert>*

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -58,3 +58,15 @@ jobs:
             Test some characters: & and * and < > \n \r
 
             Failed to assign <${{ github.event.repository.html_url }}|SDH #my-issue>.
+
+      - uses: ./slack/send
+        id: slack-multi-with-double-quotes
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#observablt-bots"
+          thread-timestamp: ${{ steps.slack-send.outputs.thread-timestamp || '' }}
+          message: |
+            :wave: <@U03HGTRTLD6>!
+            I have assigned you the following SDH, as to my knowledge you are currently on duty for `area::observability-rac`:
+
+            *`urgency:48h` <https://github.com/elastic/sdh-kibana/issues/5098|#5098 - Adding the field "system.filesystem.free" to the output of an alert>*

--- a/.github/workflows/test-slack-send.yml
+++ b/.github/workflows/test-slack-send.yml
@@ -67,6 +67,6 @@ jobs:
           thread-timestamp: ${{ steps.slack-send.outputs.thread-timestamp || '' }}
           message: |
             :wave: !
-            I have assigned you the following SDH, as to my knowledge you are currently on duty for `area::observability-rac`:
+            I have assigned you the following SDH, as to my knowledge you are currently on duty for `area::observability`:
 
-            *`urgency:48h` <https://github.com/elastic/sdh-kibana/issues/5098|#5098 - Adding the field "system.filesystem.free" to the output of an alert>*
+            *`urgency:48h` <https://github.com/elastic/kibana/issues/5098|#5098 - Adding the field "system.filesystem.free" to the output of an alert>*

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -59,9 +59,9 @@ runs:
         # Escape special characters for GitHub Actions output
         message = message.replace('\n', '\\n').replace('\r', '\\r')
 
-        echo "message is: ${message}"
+        println("message is: ${message}")
         sanitizedMessage = json.dumps(message)
-        echo "sanitized message is: ${sanitizedMessage}"
+        println("sanitized message is: ${sanitizedMessage}")
 
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("message={}".format(sanitizedMessage))

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -76,9 +76,9 @@ runs:
           unfurl_media: false
           channel: "${{ inputs.channel-id }}"
           thread_ts: "${{ inputs.thread-timestamp }}"
-          text: "${{ steps.prepare.outputs.message }}"
+          text: ${{ steps.prepare.outputs.message }}
           blocks:
             - type: "section"
               text:
                 type: mrkdwn
-                text: "${{ steps.prepare.outputs.message }}"
+                text: ${{ steps.prepare.outputs.message }}

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -59,9 +59,9 @@ runs:
         # Escape special characters for GitHub Actions output
         message = message.replace('\n', '\\n').replace('\r', '\\r')
 
-        println("message is: ${message}")
+        print("message is: ${message}")
         sanitizedMessage = json.dumps(message)
-        println("sanitized message is: ${sanitizedMessage}")
+        print("sanitized message is: ${sanitizedMessage}")
 
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("message={}".format(sanitizedMessage))

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -47,6 +47,7 @@ runs:
         # https://api.slack.com/reference/surfaces/formatting#escaping
         import os
         from urllib.parse import unquote
+        import json
 
         if os.environ["MESSAGE"]:
           message = os.environ.get('MESSAGE', 'No message')
@@ -58,8 +59,12 @@ runs:
         # Escape special characters for GitHub Actions output
         message = message.replace('\n', '\\n').replace('\r', '\\r')
 
+        echo "message is: ${message}"
+        sanitizedMessage = json.dumps(message)
+        echo "sanitized message is: ${sanitizedMessage}"
+
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
-          f.write("message={}".format(message))
+          f.write("message={}".format(sanitizedMessage))
 
     - uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       id: slack_message

--- a/slack/send/action.yml
+++ b/slack/send/action.yml
@@ -56,12 +56,9 @@ runs:
         else:
           raise Exception("message must be set.")
 
-        # Escape special characters for GitHub Actions output
-        message = message.replace('\n', '\\n').replace('\r', '\\r')
-
-        print("message is: ${message}")
+        print("message={}".format(message))
         sanitizedMessage = json.dumps(message)
-        print("sanitized message is: ${sanitizedMessage}")
+        print("sanitized message={}".format(sanitizedMessage))
 
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("message={}".format(sanitizedMessage))


### PR DESCRIPTION
Let's fix the issue when the message contains `"` 

See 

<img width="812" alt="image" src="https://github.com/user-attachments/assets/6e6712bc-78fb-439f-89b2-97af443d6fb8">
