### PR TITLE
oblt-cli: no more repo but repository flag

### DIFF
--- a/oblt-cli/cluster-create-ccs/action.yml
+++ b/oblt-cli/cluster-create-ccs/action.yml
@@ -79,7 +79,7 @@ runs:
           gitOpsFlags = []
 
           if (gitops === 'true') {
-            gitOpsFlags.push(`--repo=${context.repo.owner}/${context.repo.repo}`)
+            gitOpsFlags.push(`--repository=${context.repo.owner}/${context.repo.repo}`)
             if (context.eventName === 'pull_request') {
               gitOpsFlags.push(`--pull-request=${context.issue.number}`)
               gitOpsFlags.push(`--comment-id=${context.payload.comment.id}`)


### PR DESCRIPTION
Fixes

```
Error: unknown flag: --repo
Usage:
  oblt-cli cluster create ccs [fl
```

See https://github.com/elastic/oblt-actions/actions/runs/12226016081/job/34100714929?pr=187