### PR TITLE
feat(serverless): support wait flag

### DIFF
--- a/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
@@ -19,6 +19,19 @@ permissions:
 
 jobs:
   test:
+    if: always()
+    needs:
+      - dry-run
+      - wait
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}
+
+  dry-run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,3 +54,44 @@ jobs:
           target: 'qa'
           dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
           cluster-name-prefix: 'foo'
+
+  wait:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "read",
+              "checks": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
+
+      - uses: ./oblt-cli/cluster-create-serverless
+        id: create
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          target: 'qa'
+          dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
+          cluster-name-prefix: 'foo'
+          wait: '15'
+
+      - name: Assert is not empty
+        run: test -n "${{ steps.create.outputs.cluster-name }}"
+      # NOTE: this is just to help with tearing down the infra as a best effort
+      #             Wait 60 seconds - that's the average time it takes PRs to get merged.
+      - name: Wait 60 seconds - PRs in oblt-cli need to be merged
+        run: sleep 60
+      - uses: elastic/oblt-actions/oblt-cli/cluster-destroy@v1
+        continue-on-error: true
+        with:
+          cluster-name: ${{ steps.create.outputs.cluster-name }}
+          github-token: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-serverless.yml
@@ -80,12 +80,12 @@ jobs:
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           target: 'qa'
-          dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
           cluster-name-prefix: 'foo'
           wait: '15'
 
       - name: Assert is not empty
         run: test -n "${{ steps.create.outputs.cluster-name }}"
+
       # NOTE: this is just to help with tearing down the infra as a best effort
       #             Wait 60 seconds - that's the average time it takes PRs to get merged.
       - name: Wait 60 seconds - PRs in oblt-cli need to be merged

--- a/oblt-cli/cluster-create-serverless/README.md
+++ b/oblt-cli/cluster-create-serverless/README.md
@@ -9,17 +9,17 @@ Run the oblt-cli wrapper to create a serverless cluster.
 
 ## Inputs
 <!--inputs-->
-| Name                  | Description                                                                  | Required | Default            |
-|-----------------------|------------------------------------------------------------------------------|----------|--------------------|
-| `cluster-name-prefix` | Prefix to be prepended to the randomised cluster name                        | `false`  | ` `                |
-| `cluster-name-suffix` | Suffix to be appended to the randomised cluster name                         | `false`  | ` `                |
-| `target`              | The target environment where to deploy the serverless cluster. Default: `qa` | `false`  | `qa`               |
-| `project-type`        | The project type. Default: `observability`                                   | `false`  | `observability`    |
-| `github-token`        | The GitHub access token.                                                     | `true`   | ` `                |
-| `slack-channel`       | The slack channel to notify the status.                                      | `false`  | `#observablt-bots` |
-| `username`            | Username to show in the deployments with oblt-cli, format: [a-z0-9]          | `false`  | `obltmachine`      |
-| `gitops`              | Whether to provide the GitOps metadata to the oblt-cli                       | `false`  | `false`            |
-| `dry-run`             | Whether to dryRun                                                            | `false`  | `false`            |
+| Name                  | Description                                                                             | Required | Default            |
+|-----------------------|-----------------------------------------------------------------------------------------|----------|--------------------|
+| `cluster-name-prefix` | Prefix to be prepended to the randomised cluster name                                   | `false`  | ` `                |
+| `cluster-name-suffix` | Suffix to be appended to the randomised cluster name                                    | `false`  | ` `                |
+| `target`              | The target environment where to deploy the serverless cluster. Default: `qa`            | `false`  | `qa`               |
+| `project-type`        | The project type. Default: `observability`                                              | `false`  | `observability`    |
+| `github-token`        | The GitHub access token.                                                                | `true`   | ` `                |
+| `slack-channel`       | The slack channel to notify the status.                                                 | `false`  | `#observablt-bots` |
+| `username`            | Username to show in the deployments with oblt-cli, format: [a-z0-9]                     | `false`  | `obltmachine`      |
+| `gitops`              | Whether to provide the GitOps metadata to the oblt-cli                                  | `false`  | `false`            |
+| `dry-run`             | Whether to dryRun                                                                       | `false`  | `false`            |
 | `wait`                | it waits N minutes for the operation to finish. (default 0 if no wait time is provided) | `false`  | `0`                |
 <!--/inputs-->
 

--- a/oblt-cli/cluster-create-serverless/README.md
+++ b/oblt-cli/cluster-create-serverless/README.md
@@ -20,7 +20,15 @@ Run the oblt-cli wrapper to create a serverless cluster.
 | `username`            | Username to show in the deployments with oblt-cli, format: [a-z0-9]          | `false`  | `obltmachine`      |
 | `gitops`              | Whether to provide the GitOps metadata to the oblt-cli                       | `false`  | `false`            |
 | `dry-run`             | Whether to dryRun                                                            | `false`  | `false`            |
+| `wait`                | it waits N minutes for the operation to finish. (default 0 if no wait time is provided) | `false`  | `0`                |
 <!--/inputs-->
+
+## Outputs
+<!--outputs-->
+| Name           | Description                            |
+|----------------|----------------------------------------|
+| `cluster-name` | The cluster name that has been created |
+<!--/outputs-->
 
 ## Usage
 

--- a/oblt-cli/cluster-create-serverless/action.yml
+++ b/oblt-cli/cluster-create-serverless/action.yml
@@ -34,6 +34,16 @@ inputs:
     description: 'Whether to dryRun'
     default: 'false'
     required: false
+  wait:
+    description: 'it waits N minutes for the operation to finish. (default 0 if no wait time is provided)'
+    default: '0'
+    required: false
+
+outputs:
+  cluster-name:
+    description: 'The cluster name that has been created'
+    value: ${{ steps.info.outputs.cluster-name }}
+
 runs:
   using: "composite"
   steps:
@@ -43,7 +53,17 @@ runs:
       with:
         script: |
           console.log(`Parsing flags`)
-          const { cluster_name_prefix, cluster_name_suffix, dry_run, gitops, target, project_type  } = process.env
+          const {
+            cluster_name_prefix,
+            cluster_name_suffix,
+            dry_run,
+            gitops,
+            target,
+            project_type,
+            wait_time,
+            RUNNER_TEMP
+          } = process.env
+
           if (cluster_name_prefix != '') {
             core.setOutput('CLUSTER_NAME_PREFIX', `--cluster-name-prefix=${cluster_name_prefix}`)
           }
@@ -72,6 +92,15 @@ runs:
           parameters.EphemeralCluster = "true"
           console.log(`Create PARAMETERS env variable`)
           core.setOutput('PARAMETERS', `--parameters='${JSON.stringify(parameters)}'`)
+
+          cluster_json_file = `${RUNNER_TEMP}/cluster.json`
+          core.setOutput('cluster-json-file', `${cluster_json_file}`)
+          if (wait_time) {
+            waitFlags = []
+            waitFlags.push(`--wait=${wait_time}`)
+            waitFlags.push(`--output-file=${cluster_json_file}`)
+            core.setOutput('WAIT', waitFlags.join(' '))
+          }
       env:
         cluster_name_prefix: ${{ inputs.cluster-name-prefix }}
         cluster_name_suffix: ${{ inputs.cluster-name-suffix }}
@@ -79,6 +108,7 @@ runs:
         gitops: ${{ inputs.gitops }}
         target: ${{ inputs.target }}
         project_type: ${{ inputs.project-type }}
+        wait_time: ${{ inputs.wait }}
 
     - uses: elastic/oblt-actions/oblt-cli/setup@v1.24.5
       with:
@@ -91,7 +121,19 @@ runs:
           ${{ steps.flags.outputs.DRY_RUN }} \
           ${{ steps.flags.outputs.CLUSTER_NAME_PREFIX }} \
           ${{ steps.flags.outputs.CLUSTER_NAME_SUFFIX }} \
-          ${{ steps.flags.outputs.PARAMETERS }}
+          ${{ steps.flags.outputs.PARAMETERS }} \
+          ${{ steps.flags.outputs.WAIT }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+
+    - run: |
+        cluster_name=""
+        if [ -f "${cluster_json}" ]; then
+          cluster_name=$(jq -r '.ClusterName' < "${cluster_json}")
+        fi
+        echo "cluster-name=${cluster_name}" >> "$GITHUB_OUTPUT"
+      id: info
+      shell: bash
+      env:
+        cluster_json: "${{ steps.flags.outputs.cluster-json-file }}"


### PR DESCRIPTION
Similarly done in the past with https://github.com/elastic/oblt-actions/pull/226


#### What


* Support wait so it can be used in conjunction with `oblt-cli/cluster-credentials`
* Output the cluster-name

#### Usage


```yaml

      - name: Get token
        id: get_token
        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
        with:
          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
          permissions: >-
            {
              "contents": "write",
              "pull_requests": "read",
              "checks": "read"
            }
          repositories: >-
            ["observability-test-environments"]

      - uses: elastic/oblt-actions/git/setup@v1
        with:
          github-token: ${{ steps.get_token.outputs.token }}

      - name: Setup ephemeral cluster
        uses: elastic/oblt-actions/oblt-cli/cluster-create-serverless@v1
        id: cluster_create
        with:
          github-token: ${{ steps.get_token.outputs.token }}
          wait: 15
          [..]

      - name: Setup credentials for the ephemeral cluster
        uses: elastic/oblt-actions/oblt-cli/cluster-credentials@v1
        with:
          cluster-name: ${{ steps.cluster_create.outputs.cluster-name }}
          github-token: ${{ steps.get_token.outputs.token }}

[..]


      - name: Tear down ephemeral cluster
        uses: elastic/oblt-actions/oblt-cli/cluster-destroy@v1
        if: always()
        continue-on-error: true
        with:
          github-token: ${{ steps.get_token.outputs.token }}
          cluster-name: ${{ steps.cluster_create.outputs.cluster-name }}
```