### PR TITLE
chore: update Kibana build flags

### DIFF
--- a/kibana-docker-image/build-and-push.sh
+++ b/kibana-docker-image/build-and-push.sh
@@ -44,6 +44,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
         --skip-docker-contexts \
         --skip-docker-ubi \
         --skip-docker-wolfi \
+        --skip-docker-fips \
         --skip-generic-folders \
         --skip-platform-folders \
         --skip-docker-serverless
@@ -60,6 +61,8 @@ else
         --skip-cdn-assets \
         --skip-docker-contexts \
         --skip-docker-ubi \
+        --skip-docker-wolfi \
+        --skip-docker-fips \
         --skip-docker-ubuntu \
         --skip-docker-cloud
 fi


### PR DESCRIPTION
There are new Docker image types we do not need to compile