### PR TITLE
feat: help with reusing the github actions commands

### DIFF
--- a/.github/workflows/no-test.yml
+++ b/.github/workflows/no-test.yml
@@ -12,6 +12,7 @@ on:
       - '!aws/auth/**'
       - '!buildkite/run/**'
       - '!check-dependent-jobs/**'
+      - '!elastic/github-commands/**'
       - '!git/setup/**'
       - '!github/backport-active/**'
       - '!github/project-add/**'

--- a/.github/workflows/test-elastic-github-commands.yml
+++ b/.github/workflows/test-elastic-github-commands.yml
@@ -1,0 +1,23 @@
+name: test-elastic-github-commands
+
+on:
+  merge_group: ~
+  workflow_dispatch: ~
+  pull_request:
+    paths:
+      - '.github/workflows/test-elastic-github-commands.yml'
+      - 'elastic/github-commands/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./elastic/github-commands

--- a/elastic/github-commands/README.md
+++ b/elastic/github-commands/README.md
@@ -1,0 +1,50 @@
+# <!--name-->elastic/github-commands<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Felastic%2Fgithub-commands+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-elastic-github-commands](https://github.com/elastic/oblt-actions/actions/workflows/test-elastic-github-commands.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-elastic-github-commands.yml)
+
+<!--description-->
+Print the supported GitHub commands
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name                | Description                   | Required | Default               |
+|---------------------|-------------------------------|----------|-----------------------|
+| `github-token`      | The GitHub access token.      | `false`  | `${{ github.token }}` |
+| `continue-on-error` | Whether to continue on error. | `false`  | `true`                |
+<!--/inputs-->
+
+## Outputs
+
+<!--outputs-->
+| Name | Description |
+|------|-------------|
+<!--/outputs-->
+
+## Usage
+
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+---
+name: github-commands-comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: elastic/oblt-actions/elastic/github-commands@v1
+
+```
+
+<!--/usage-->

--- a/elastic/github-commands/action.yml
+++ b/elastic/github-commands/action.yml
@@ -1,0 +1,39 @@
+name: elastic/github-commands
+description: Print the supported GitHub commands
+inputs:
+  github-token:
+    description: 'The GitHub access token.'
+    required: false
+    type: string
+    default: ${{ github.token }}
+  continue-on-error:
+    description: 'Whether to continue on error.'
+    required: false
+    type: boolean
+    default: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      continue-on-error: true
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const body = `
+            ### :robot: GitHub comments
+
+            <details><summary>Expand to view the GitHub comments</summary>
+            <p>
+
+            Just comment with:
+            - \`run\` \`docs-build\` : Re-trigger the docs validation. (use unformatted text in the comment!)
+            </p>
+            </details>
+          `.replace(/  +/g, '')
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          })


### PR DESCRIPTION
Encapsulates the GitHub comments so consumers don't need to care about the specifics but easily use it.