### PR TITLE
feat: add wait for the cluster-create-custom

### DIFF
--- a/.github/workflows/test-oblt-cli-cluster-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-cluster-create-custom.yml
@@ -24,6 +24,7 @@ jobs:
       - no-gitops
       - gitops
       - multiline
+      - wait
     runs-on: ubuntu-latest
     steps:
       - id: check
@@ -114,3 +115,44 @@ jobs:
               "StackVersion": "8.7.0",
               "KibanaDockerImage": "docker.elastic.co/observability-ci/kibana-cloud:8.7.0-SNAPSHOT"
             }
+
+  wait:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["observability-test-environments"]
+      - uses: ./oblt-cli/cluster-create-custom
+        id: create
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          template: 'deploy-kibana'
+          cluster-name-prefix: 'testgithubaction'
+          gitops: false
+          dry-run: ${{ github.event.inputs.dry-run != '' && github.event.inputs.dry-run || true }}
+          parameters: '{"RemoteClusterName":"release-oblt","StackVersion":"8.7.0","KibanaDockerImage":"docker.elastic.co/observability-ci/kibana-cloud:8.7.0-SNAPSHOT"}'
+          wait: '15'
+
+      - name: Assert is not empty
+        run: test -n "${{ steps.create.outputs.cluster-name }}"
+
+      # NOTE: this is just to help with tearing down the infra as a best effort
+      #             Wait 60 seconds - that's the average time it takes PRs to get merged.
+      - name: Wait 60 seconds - PRs in oblt-cli need to be merged
+        run: sleep 60
+      - uses: elastic/oblt-actions/oblt-cli/cluster-destroy@v1
+        continue-on-error: true
+        with:
+          cluster-name: ${{ steps.create.outputs.cluster-name }}
+          github-token: ${{ steps.get_token.outputs.token }}

--- a/oblt-cli/cluster-create-custom/README.md
+++ b/oblt-cli/cluster-create-custom/README.md
@@ -9,19 +9,27 @@ Run the oblt-cli wrapper to create a custom cluster.
 
 ## Inputs
 <!--inputs-->
-| Name                  | Description                                                         | Required | Default            |
-|-----------------------|---------------------------------------------------------------------|----------|--------------------|
-| `template`            | The Oblt cluster template to use                                    | `true`   | ` `                |
-| `parameters`          | The Oblt cluster parameters to use in JSON format.                  | `true`   | `{}`               |
-| `github-token`        | The GitHub access token.                                            | `true`   | ` `                |
-| `cluster-name-prefix` | Prefix to be prepended to the randomised cluster name               | `false`  | ` `                |
-| `cluster-name-suffix` | Suffix to be appended to the randomised cluster name                | `false`  | ` `                |
-| `slack-channel`       | The slack channel to notify the status.                             | `false`  | `#observablt-bots` |
-| `username`            | Username to show in the deployments with oblt-cli, format: [a-z0-9] | `false`  | `obltmachine`      |
-| `gitops`              | Whether to provide the GitOps metadata to the oblt-cli              | `false`  | `false`            |
-| `dry-run`             | Whether to dryRun                                                   | `false`  | `false`            |
-| `skip-random-name`    | Whether to deploy a cluster with a random name                      | `false`  | `false`            |
+| Name                  | Description                                                                             | Required | Default            |
+|-----------------------|-----------------------------------------------------------------------------------------|----------|--------------------|
+| `template`            | The Oblt cluster template to use                                                        | `true`   | ` `                |
+| `parameters`          | The Oblt cluster parameters to use in JSON format.                                      | `true`   | `{}`               |
+| `github-token`        | The GitHub access token.                                                                | `true`   | ` `                |
+| `cluster-name-prefix` | Prefix to be prepended to the randomised cluster name                                   | `false`  | ` `                |
+| `cluster-name-suffix` | Suffix to be appended to the randomised cluster name                                    | `false`  | ` `                |
+| `slack-channel`       | The slack channel to notify the status.                                                 | `false`  | `#observablt-bots` |
+| `username`            | Username to show in the deployments with oblt-cli, format: [a-z0-9]                     | `false`  | `obltmachine`      |
+| `gitops`              | Whether to provide the GitOps metadata to the oblt-cli                                  | `false`  | `false`            |
+| `dry-run`             | Whether to dryRun                                                                       | `false`  | `false`            |
+| `skip-random-name`    | Whether to deploy a cluster with a random name                                          | `false`  | `false`            |
+| `wait`                | it waits N minutes for the operation to finish. (default 0 if no wait time is provided) | `false`  | `0`                |
 <!--/inputs-->
+
+## Outputs
+<!--outputs-->
+| Name           | Description                            |
+|----------------|----------------------------------------|
+| `cluster-name` | The cluster name that has been created |
+<!--/outputs-->
 
 ## Usage
 <!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->

--- a/oblt-cli/cluster-create-custom/README.md
+++ b/oblt-cli/cluster-create-custom/README.md
@@ -50,6 +50,6 @@ jobs:
           template: 'deploy-kibana'
           cluster-name-prefix: 'foo'
           parameters: '{"RemoteClusterName":"release-oblt","StackVersion":"8.7.0","ElasticsearchDockerImage":"docker.elastic.co/observability-ci/elasticsearch-cloud-ess:8.7.0-046d305b","KibanaDockerImage":"docker.elastic.co/observability-ci/kibana-cloud:8.7.0-SNAPSHOT-87"}'
-          token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
 ```
 <!--/usage-->

--- a/oblt-cli/cluster-create-custom/action.yml
+++ b/oblt-cli/cluster-create-custom/action.yml
@@ -37,6 +37,16 @@ inputs:
     description: 'Whether to deploy a cluster with a random name'
     default: false
     required: false
+  wait:
+    description: 'it waits N minutes for the operation to finish. (default 0 if no wait time is provided)'
+    default: '0'
+    required: false
+
+outputs:
+  cluster-name:
+    description: 'The cluster name that has been created'
+    value: ${{ steps.info.outputs.cluster-name }}
+
 runs:
   using: "composite"
   steps:
@@ -51,6 +61,7 @@ runs:
         gitops: ${{ inputs.gitops }}
         input_parameters: ${{ inputs.parameters }}
         skip_random_name: ${{ inputs.skip-random-name }}
+        wait_time: ${{ inputs.wait }}
       with:
         script: |
           const {
@@ -97,6 +108,15 @@ runs:
             core.setOutput('SKIP_RANDOM_NAME', '--skip-random-name')
           }
 
+          cluster_json_file = `${RUNNER_TEMP}/cluster.json`
+          core.setOutput('cluster-json-file', `${cluster_json_file}`)
+          if (wait_time) {
+            waitFlags = []
+            waitFlags.push(`--wait=${wait_time}`)
+            waitFlags.push(`--output-file=${cluster_json_file}`)
+            core.setOutput('WAIT', waitFlags.join(' '))
+          }
+
     - uses: elastic/oblt-actions/oblt-cli/setup@v1.28.0
       with:
         github-token: ${{ inputs.github-token }}
@@ -110,7 +130,19 @@ runs:
             ${{ steps.flags.outputs.CLUSTER_NAME_PREFIX }} \
             ${{ steps.flags.outputs.CLUSTER_NAME_SUFFIX }} \
             ${{ steps.flags.outputs.PARAMETERS }} \
-            ${{ steps.flags.outputs.SKIP_RANDOM_NAME }}
+            ${{ steps.flags.outputs.SKIP_RANDOM_NAME }} \
+            ${{ steps.flags.outputs.WAIT }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+
+    - run: |
+        cluster_name=""
+        if [ -f "${cluster_json}" ]; then
+          cluster_name=$(jq -r '.ClusterName' < "${cluster_json}")
+        fi
+        echo "cluster-name=${cluster_name}" >> "$GITHUB_OUTPUT"
+      id: info
+      shell: bash
+      env:
+        cluster_json: "${{ steps.flags.outputs.cluster-json-file }}"


### PR DESCRIPTION
Duplicates https://github.com/elastic/oblt-actions/pull/285 so it can run in the CI 

Add support for `wait` when creating a custom cluster, that's something we enabled for the serverless one at https://github.com/elastic/oblt-actions/pull/242

Notifies https://github.com/elastic/elastic-agent/pull/8263