### PR TITLE
fix: when running without dry-run pass the repository too

### DIFF
--- a/mergify/labels-copier/copy.sh
+++ b/mergify/labels-copier/copy.sh
@@ -35,5 +35,5 @@ echo ">> $labels will be added"
 if [ "$DRY_RUN" == "true" ]; then
   echo ">> DRY_RUN is set, skipping the label addition"
 else
-  gh pr edit --add-label "$labels" "$PR_URL"
+  gh pr edit --repo "$REPOSITORY" --add-label "$labels" "$PR_URL"
 fi


### PR DESCRIPTION
<img width="953" alt="image" src="https://github.com/user-attachments/assets/4669c8c9-c0c3-43f1-8f8e-8605896340e3" />
