### PR TITLE
Fix example action name to cluster-create-serverless

### DIFF
--- a/oblt-cli/cluster-create-serverless/README.md
+++ b/oblt-cli/cluster-create-serverless/README.md
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/oblt-actions/git/setup@v1
-      - uses: elastic/oblt-actions/oblt-cli/create-serverless@v1
+      - uses: elastic/oblt-actions/oblt-cli/cluster-create-serverless@v1
         with:
           target: 'staging'
           cluster-name-prefix: 'foo'


### PR DESCRIPTION
### Summary

Fix action name from `create-serverless` to `cluster-create-serverless` in the example of the README.md file