### PR TITLE
updatecli: honour the labels for the automated changelog generator

### DIFF
--- a/.ci/updatecli/values.d/scm.yml
+++ b/.ci/updatecli/values.d/scm.yml
@@ -8,3 +8,8 @@ scm:
   user: obltmachine
   email: obltmachine@users.noreply.github.com
   # end update-compose policy values
+
+# update-compose policy uses a different data structure for the
+# labels, so we need to use a different key
+labels:
+  - 'changelog:dependencies'


### PR DESCRIPTION
See https://github.com/updatecli/policies/blob/8c4fd78886660c2500376d4f7ef7febbb7f38a29/updatecli/policies/autodiscovery/updatecli/values.yaml#L4-L5

So the automation with the changelog validation in the CI can works out of the box, otherwise https://github.com/elastic/oblt-actions/actions/runs/16436064616/job/46446167383?pr=318#step:5:12

