### PR TITLE
feat: consider skipped job as success

### DIFF
--- a/.github/workflows/test-check-dependent-jobs.yml
+++ b/.github/workflows/test-check-dependent-jobs.yml
@@ -39,7 +39,7 @@ jobs:
   test-success:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./check-dependent-jobs
         id: check
         with:
@@ -50,7 +50,7 @@ jobs:
   test-failure-and-success:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./check-dependent-jobs
         id: check-2
         with:
@@ -61,7 +61,7 @@ jobs:
   test-failures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./check-dependent-jobs
         id: check-3
         with:
@@ -72,7 +72,7 @@ jobs:
   test-skipped-default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./check-dependent-jobs
         id: check-4
         with:
@@ -83,11 +83,11 @@ jobs:
   test-skipped-opt-in:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./check-dependent-jobs
         id: check-5
         with:
           jobs: '{ "job-a": { "result": "success" }, "job-b": { "result": "skipped" } }'
-          include-skipped: 'true'
+          skipped-as-success: 'true'
       - name: assert outputs.is-success==true
         run: test "${{ steps.check-5.outputs.is-success }}" = "true"

--- a/.github/workflows/test-check-dependent-jobs.yml
+++ b/.github/workflows/test-check-dependent-jobs.yml
@@ -21,6 +21,22 @@ permissions:
 
 jobs:
   test:
+    if: always()
+    needs:
+      - test-success
+      - test-failure-and-success
+      - test-failures
+      - test-skipped-default
+      - test-skipped-opt-in
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.is-success }}
+
+  test-success:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +47,10 @@ jobs:
       - name: assert outputs.is-success==true
         run: test "${{ steps.check.outputs.is-success }}" = "true"
 
+  test-failure-and-success:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./check-dependent-jobs
         id: check-2
         with:
@@ -38,6 +58,10 @@ jobs:
       - name: assert outputs.is-success==false
         run: test "${{ steps.check-2.outputs.is-success }}" = "false"
 
+  test-failures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./check-dependent-jobs
         id: check-3
         with:
@@ -45,6 +69,10 @@ jobs:
       - name: assert outputs.is-success==false
         run: test "${{ steps.check-3.outputs.is-success }}" = "false"
 
+  test-skipped-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./check-dependent-jobs
         id: check-4
         with:
@@ -52,6 +80,10 @@ jobs:
       - name: assert outputs.is-success==false
         run: test "${{ steps.check-4.outputs.is-success }}" = "false"
 
+  test-skipped-opt-in:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./check-dependent-jobs
         id: check-5
         with:

--- a/.github/workflows/test-check-dependent-jobs.yml
+++ b/.github/workflows/test-check-dependent-jobs.yml
@@ -30,15 +30,32 @@ jobs:
           jobs: '{ "job-a": { "result": "success" }, "job-b": { "result": "success" } }'
       - name: assert outputs.is-success==true
         run: test "${{ steps.check.outputs.is-success }}" = "true"
+
       - uses: ./check-dependent-jobs
         id: check-2
         with:
           jobs: '{ "job-a": { "result": "success" }, "job-b": { "result": "failure" } }'
       - name: assert outputs.is-success==false
         run: test "${{ steps.check-2.outputs.is-success }}" = "false"
+
       - uses: ./check-dependent-jobs
         id: check-3
         with:
           jobs: '{ "job-a": { "result": "failure" }, "job-b": { "result": "failure" } }'
       - name: assert outputs.is-success==false
         run: test "${{ steps.check-3.outputs.is-success }}" = "false"
+
+      - uses: ./check-dependent-jobs
+        id: check-4
+        with:
+          jobs: '{ "job-a": { "result": "success" }, "job-b": { "result": "skipped" } }'
+      - name: assert outputs.is-success==false
+        run: test "${{ steps.check-4.outputs.is-success }}" = "false"
+
+      - uses: ./check-dependent-jobs
+        id: check-5
+        with:
+          jobs: '{ "job-a": { "result": "success" }, "job-b": { "result": "skipped" } }'
+          include-skipped: 'true'
+      - name: assert outputs.is-success==true
+        run: test "${{ steps.check-5.outputs.is-success }}" = "true"

--- a/check-dependent-jobs/README.md
+++ b/check-dependent-jobs/README.md
@@ -9,10 +9,10 @@ Evaluates the combined the status results of the provided needs context.
 
 ## Inputs
 <!--inputs-->
-| Name              | Description                                    | Required | Default |
-|-------------------|------------------------------------------------|----------|---------|
-| `jobs`            | needs context as JSON string                   | `true`   | ` `     |
-| `include-skipped` | Whether to consider skipped jobs as successful | `false`  | `false` |
+| Name                 | Description                                    | Required | Default |
+|----------------------|------------------------------------------------|----------|---------|
+| `jobs`               | needs context as JSON string                   | `true`   | ` `     |
+| `skipped-as-success` | Whether to consider skipped jobs as successful | `false`  | `false` |
 <!--/inputs-->
 
 ## Outputs

--- a/check-dependent-jobs/README.md
+++ b/check-dependent-jobs/README.md
@@ -9,9 +9,10 @@ Evaluates the combined the status results of the provided needs context.
 
 ## Inputs
 <!--inputs-->
-| Name   | Description                  | Required | Default |
-|--------|------------------------------|----------|---------|
-| `jobs` | needs context as JSON string | `true`   | ` `     |
+| Name              | Description                                    | Required | Default |
+|-------------------|------------------------------------------------|----------|---------|
+| `jobs`            | needs context as JSON string                   | `true`   | ` `     |
+| `include-skipped` | Whether to consider skipped jobs as successful | `false`  | `false` |
 <!--/inputs-->
 
 ## Outputs

--- a/check-dependent-jobs/action.yml
+++ b/check-dependent-jobs/action.yml
@@ -5,6 +5,10 @@ inputs:
   jobs:
     required: true
     description: needs context as JSON string
+  include-skipped:
+    required: false
+    default: 'false'
+    description: Whether to consider skipped jobs as successful
 outputs:
   is-success:
     description: The evaluated result of all provided jobs in the needs context.
@@ -20,8 +24,17 @@ runs:
       with:
         script: |
           const jobs = JSON.parse(process.env.JOBS)
-          const isSuccess = Object.values(jobs).every(job => job.result === 'success' || job.result === 'skipped')
+          const includeSkipped = process.env.INCLUDE_SKIPPED === 'true'
+
+          let isSuccess
+          if (includeSkipped) {
+            isSuccess = Object.values(jobs).every(job => job.result === 'success' || job.result === 'skipped')
+          } else {
+            isSuccess = Object.values(jobs).every(job => job.result === 'success')
+          }
+
           core.setOutput('is-success', isSuccess)
           core.setOutput('status', isSuccess ? 'success' : 'failure')
       env:
         JOBS: ${{ inputs.jobs }}
+        INCLUDE_SKIPPED: ${{ inputs.include-skipped }}

--- a/check-dependent-jobs/action.yml
+++ b/check-dependent-jobs/action.yml
@@ -5,7 +5,7 @@ inputs:
   jobs:
     required: true
     description: needs context as JSON string
-  include-skipped:
+  skipped-as-success:
     required: false
     default: 'false'
     description: Whether to consider skipped jobs as successful
@@ -37,4 +37,4 @@ runs:
           core.setOutput('status', isSuccess ? 'success' : 'failure')
       env:
         JOBS: ${{ inputs.jobs }}
-        INCLUDE_SKIPPED: ${{ inputs.include-skipped }}
+        INCLUDE_SKIPPED: ${{ inputs.skipped-as-success }}

--- a/check-dependent-jobs/action.yml
+++ b/check-dependent-jobs/action.yml
@@ -20,7 +20,7 @@ runs:
       with:
         script: |
           const jobs = JSON.parse(process.env.JOBS)
-          const isSuccess = Object.values(jobs).every(job => job.result === 'success')
+          const isSuccess = Object.values(jobs).every(job => job.result === 'success' || job.result === 'skipped')
           core.setOutput('is-success', isSuccess)
           core.setOutput('status', isSuccess ? 'success' : 'failure')
       env:


### PR DESCRIPTION
check-dependant-jobs is reporting a success if all the dependant jobs have a 'success' job.result.  This is causing issues when a job is skipped and the workflow succeed but still reports a failure in slack.

An example can be observed at https://github.com/elastic/apm-server/actions/runs/17391488346/job/49367574571

```
    jobs: {
    "run-upgrade": {
      "result": "success",
      "outputs": {}
    },
    "run-upgrade-bc": {
      "result": "skipped",
      "outputs": {}
    },
    "run-standalone": {
      "result": "success",
      "outputs": {}
    }
  }
```

Closes https://github.com/elastic/apm-server/issues/18400

credits to @ericywl for spotting the issue