### PR TITLE
feat: oblt-cli cluster list action

### DIFF
--- a/.github/workflows/test-oblt-cli-list.yml
+++ b/.github/workflows/test-oblt-cli-list.yml
@@ -1,0 +1,41 @@
+name: test-oblt-cli-list
+
+on:
+  merge_group: ~
+  workflow_dispatch: ~
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-oblt-cli-list.yml'
+      - 'oblt-cli/run/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-oblt-cli-list.yml'
+      - 'oblt-cli/run/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "read"
+            }
+          repositories: >-
+            ["observability-test-environments"]
+      - uses: ./oblt-cli/list
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}

--- a/oblt-cli/list/README.md
+++ b/oblt-cli/list/README.md
@@ -1,0 +1,43 @@
+# <!--name-->oblt-cli/list<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Foblt-cli%list+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-oblt-cli-list](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-list.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-oblt-cli-list.yml)
+
+<!--description-->
+List clusters using a filter
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name            | Description                                                                            | Required | Default            |
+|-----------------|----------------------------------------------------------------------------------------|----------|--------------------|
+| `github-token`  | The GitHub access token.                                                               | `true`   | ` `                |
+| `slack-channel` | The slack channel to notify the status.                                                | `false`  | `#observablt-bots` |
+| `username`      | Username to show in the deployments with oblt-cli, format: [a-z0-9]                    | `false`  | `obltmachine`      |
+| `version`       | The oblt-cli version to use.                                                           | `false`  | ` `                |
+| `verbose`       | Run oblt-cli in verbose mode.                                                          | `false`  | `false`            |
+| `filter-key`    | The filter key to use.                                                                 | `false`  | ` `                |
+| `filter-value`  | The filter value to use.                                                               | `false`  | ` `                |
+| `all`           | List all clusters.                                                                     | `false`  | `false`            |
+| `fail-on-empty` | Fail the action if no clusters are found.                                              | `false`  | `false`            |
+| `save-to-file`  | File path to save the output to.                                                       | `false`  | `clusters.json`    |
+| `version-file`  | File containing the oblt-cli version to use. If set, this overrides the version input. | `false`  | ` `                |
+<!--/inputs-->
+
+## Usage
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+jobs:
+  run-oblt-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/oblt-cli/list@v1
+        with:
+          filter-key: "stack.update_schedule"
+          filter-value: "monday"
+          save-to-file: "${{ github.workspace }}/updates.json"
+          verbose: 'true'
+          all: 'true'
+          github-token: ${{ secrets.PAT_TOKEN }}
+```
+<!--/usage-->

--- a/oblt-cli/list/action.yml
+++ b/oblt-cli/list/action.yml
@@ -1,0 +1,81 @@
+name: 'oblt-cli/list'
+description: 'List clusters using a filter'
+inputs:
+  github-token:
+    description: 'The GitHub access token.'
+    required: true
+  slack-channel:
+    description: 'The slack channel to notify the status.'
+    default: '#observablt-bots'
+    required: false
+  username:
+    description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
+    default: 'obltmachine'
+    required: false
+  version:
+    description: 'The oblt-cli version to use.'
+    required: false
+  verbose:
+    description: 'Run oblt-cli in verbose mode.'
+    required: false
+    default: 'false'
+  filter-key:
+    description: 'The filter key to use.'
+    required: false
+  filter-value:
+    description: 'The filter value to use.'
+    required: false
+  all:
+    description: 'List all clusters.'
+    required: false
+    default: 'false'
+  fail-on-empty:
+    description: 'Fail the action if no clusters are found.'
+    required: false
+    default: 'false'
+  save-to-file:
+    description: 'File path to save the output to.'
+    required: false
+    default: 'clusters.json'
+  version-file:
+    description: 'File containing the oblt-cli version to use. If set, this overrides the version input.'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - uses: elastic/oblt-actions/oblt-cli/setup@v1.30.0
+      with:
+        github-token: ${{ inputs.github-token }}
+        slack-channel: ${{ inputs.slack-channel }}
+        username: ${{ inputs.username }}
+        version: ${{ inputs.version }}
+        version-file: ${{ inputs.version-file }}
+    - name: run oblt-cli
+      env:
+        VERBOSE: ${{ inputs.verbose }}
+        FILTER_KEY: ${{ inputs.filter-key || '' }}
+        FILTER_VALUE: ${{ inputs.filter-value || '' }}
+        ALL: ${{ inputs.all }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        SAVE_TO_FILE: ${{ inputs.save-to-file }}
+        FAIL_ON_EMPTY: ${{ inputs.fail-on-empty }}
+      run: |
+        COMMAND="oblt-cli cluster list"
+        if [ "${VERBOSE}" == "true" ] || [ -n "${RUNNER_DEBUG}" == "1" ]; then
+          COMMAND="${COMMAND} --verbose"
+        fi
+        if [ "${ALL}" == "true" ]; then
+          COMMAND="${COMMAND} --all"
+        fi
+        if [ -n "${FILTER_KEY}" ] && [ -n "${FILTER_VALUE}" ]; then
+          COMMAND="${COMMAND} --filter \"${FILTER_KEY}=${FILTER_VALUE}\""
+        fi
+        if [ -n "${SAVE_TO_FILE}" ]; then
+          COMMAND="${COMMAND} --output-file \"${SAVE_TO_FILE}\""
+        fi
+        if [ "${FAIL_ON_EMPTY}" == "false" ]; then
+          COMMAND="${COMMAND} || true"
+        fi
+        echo "Running command: ${COMMAND}"
+        eval "${COMMAND}"
+      shell: bash


### PR DESCRIPTION
New action to execute the command `oblt-cli cluster list` with proper parameters. It avoids using the `oblt-cli/run` action and changes the approach to use narrored actions.