### PR TITLE
github user type detection fix for Copilot

### DIFF
--- a/.github/workflows/no-test.yml
+++ b/.github/workflows/no-test.yml
@@ -20,6 +20,7 @@ on:
       - '!github/changed-files/**'
       - '!github/project-add/**'
       - '!github/project-field-set/**'
+      - '!github/user-type/**'
       - '!google/auth/**'
       - '!oblt-cli/cluster-name-validation/**'
       - '!oblt-cli/list/**'

--- a/.github/workflows/test-github-user-type.yml
+++ b/.github/workflows/test-github-user-type.yml
@@ -49,6 +49,31 @@ jobs:
       - name: Assert is bot
         run: test "${{steps.validation.outputs.result}}" = "bot"
 
+  copilot-is-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: elastic/oblt-actions/git/setup@v1
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "members": "read"
+            }
+      - uses: ./github/user-type
+        id: validation
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          github-user: "Copilot"
+
+      - name: Assert is bot
+        run: test "${{steps.validation.outputs.result}}" = "bot"
+
+
   is-not-bot:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-github-user-type.yml
+++ b/.github/workflows/test-github-user-type.yml
@@ -53,14 +53,11 @@ jobs:
       - uses: elastic/oblt-actions/git/setup@v1
       - name: Get token
         id: get_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          permissions: >-
-            {
-              "members": "read"
-            }
+          app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions-members: read
       - uses: ./github/user-type
         id: validation
         with:

--- a/github/user-type/action.yml
+++ b/github/user-type/action.yml
@@ -23,10 +23,17 @@ runs:
       id: gh-api-user-type
       run: |
         # will produce a 404 and non-zero status when user does not exists
-        # API result is normalized to lower-case, known values: 'Bot', 'User
-        type=$(gh api \
-          -H "Accept: application/vnd.github+json" \
-          /users/${{ env.GH_USER }} --jq .type | tr '[:upper:]' '[:lower:]')
+        # API result is normalized to lower-case, known values: 'Bot', 'User'
+
+        if [[ 'Copilot' == "${{ env.GH_USER }}" ]]; then
+          # special case for GitHub Copilot:
+          # API returns a 404 for profile access but is 'Bot' as we can see in PRs.
+          type = 'bot'
+        else
+          type=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /users/${{ env.GH_USER }} --jq .type | tr '[:upper:]' '[:lower:]')
+        fi
 
         echo "result=${type}" >> "${GITHUB_OUTPUT}"
         echo "::debug::GitHub user type = ${type}"


### PR DESCRIPTION
When a PR is opened by Copilot, the `github/user-type` action fails with a 404 error.

This is because the following API call fails with a 404
```bash
gh api -H "Accept: application/vnd.github+json" '/users/Copilot' 
```

The surprising part is that we have access to the same data when querying the pull-request (but this action can't as it uses the user login as input, not the PR).

For example with
```bash
gh api -H "Accept: application/vnd.github+json" '/repos/elastic/apm-agent-java/pulls/4221'  
```

We do get the user type from the returned JSON:
```json
{
  "url": "https://api.github.com/repos/elastic/apm-agent-java/pulls/4221",
  "id": 2843476620,
  "node_id": "PR_kwDOBznsDs6pfAKM",
  "html_url": "https://github.com/elastic/apm-agent-java/pull/4221",
  "diff_url": "https://github.com/elastic/apm-agent-java/pull/4221.diff",
  "patch_url": "https://github.com/elastic/apm-agent-java/pull/4221.patch",
  "issue_url": "https://api.github.com/repos/elastic/apm-agent-java/issues/4221",
  "number": 4221,
  "state": "open",
  "locked": false,
  "title": "Replace tibdex/github-app-token with actions/create-github-app-token",
  "user": {
    "login": "Copilot",
    "id": 198982749,
    "node_id": "BOT_kgDOC9w8XQ",
    "avatar_url": "https://avatars.githubusercontent.com/in/1143301?v=4",
    "gravatar_id": "",
    "url": "https://api.github.com/users/Copilot", <--- URL that fails with a 404
    "html_url": "https://github.com/apps/copilot-swe-agent",
    "followers_url": "https://api.github.com/users/Copilot/followers",
    "following_url": "https://api.github.com/users/Copilot/following{/other_user}",
    "gists_url": "https://api.github.com/users/Copilot/gists{/gist_id}",
    "starred_url": "https://api.github.com/users/Copilot/starred{/owner}{/repo}",
    "subscriptions_url": "https://api.github.com/users/Copilot/subscriptions",
    "organizations_url": "https://api.github.com/users/Copilot/orgs",
    "repos_url": "https://api.github.com/users/Copilot/repos",
    "events_url": "https://api.github.com/users/Copilot/events{/privacy}",
    "received_events_url": "https://api.github.com/users/Copilot/received_events",
    "type": "Bot", <--- We do have the user type here, which is a bot as expected
    "user_view_type": "public",
    "site_admin": false
  },
  ...
```