### PR TITLE
pre-commit: lint github actions

### DIFF
--- a/.github/workflows/test-git-setup.yml
+++ b/.github/workflows/test-git-setup.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./git/setup
       - name: validate git user
-        run: test $(git config user.name) = "obltmachine"
+        run: test "$(git config user.name)" = "obltmachine"
       - name: validate git email
-        run: test $(git config user.email) = "obltmachine@users.noreply.github.com"
+        run: test "$(git config user.email)" = "obltmachine@users.noreply.github.com"
       - name: validate GIT_USER env
         run: test "${GIT_USER}" = "obltmachine"
       - name: validate GIT_EMAIL env

--- a/.github/workflows/test-updatecli-install.yml
+++ b/.github/workflows/test-updatecli-install.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./updatecli/install
       - name: Verify updatecli version
         run: |
-          want=$(cat updatecli/install/.default-updatecli-version | cut -dv -f2)
+          want=$(cut -dv -f2 < updatecli/install/.default-updatecli-version)
           got=$(updatecli version 2>&1)
           echo "${got} == ${want}"
           [[ "${got}" == *"${want}"* ]]

--- a/.github/workflows/test-updatecli-run.yml
+++ b/.github/workflows/test-updatecli-run.yml
@@ -43,7 +43,7 @@ jobs:
           command: help
       - name: Verify updatecli version
         run: |
-          want=$(cat updatecli/install/.default-updatecli-version | cut -dv -f2)
+          want=$(cut -dv -f2 < updatecli/install/.default-updatecli-version)
           got=$(updatecli version 2>&1)
           echo "${got} == ${want}"
           [[ "${got}" == *"${want}"* ]]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: actionlint
         exclude: |
           (?x)^(
-              github/workflows/test-version-framework.yml
+              .github/workflows/test-version-framework.yml
           )$
 
   # For GitHub composite actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,4 @@ repos:
     rev: 2d21e3da5122221892c195c0cff8ee47973faf4c  # frozen: 0.34.0
     hooks:
       - id: check-github-actions
+        files: action\.(yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
           - --env=VERSION=v1
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    # Support https://github.com/rhysd/actionlint/pull/561
+    rev: 0c610de366faf857ef4b33704ee28edcf85778cc
     hooks:
       - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,10 @@ repos:
               .github/workflows/test-version-framework.yml
           )$
 
-  # For GitHub composite actions
-  # see
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 2d21e3da5122221892c195c0cff8ee47973faf4c  # frozen: 0.34.0
-    hooks:
-      - id: check-github-actions
-        files: action\.(yml|yaml)$
+  # For GitHub composite actions - use an alternative approach
+  # see https://github.com/rhysd/actionlint/issues/46
+  #- repo: https://github.com/python-jsonschema/check-jsonschema
+  #  rev: 2d21e3da5122221892c195c0cff8ee47973faf4c  # frozen: 0.34.0
+  #  hooks:
+  #    - id: check-github-actions
+  #      files: action\.(yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,10 @@ repos:
     rev: 0c610de366faf857ef4b33704ee28edcf85778cc
     hooks:
       - id: actionlint
+
+  # For GitHub composite actions
+  # see
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 2d21e3da5122221892c195c0cff8ee47973faf4c  # frozen: 0.34.0
+    hooks:
+      - id: check-github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
         verbose: true
         args:
           - --env=VERSION=v1
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,10 @@ repos:
     rev: 0c610de366faf857ef4b33704ee28edcf85778cc
     hooks:
       - id: actionlint
+        exclude: |
+          (?x)^(
+              github/workflows/test-version-framework.yml
+          )$
 
   # For GitHub composite actions
   # see


### PR DESCRIPTION
Use  https://github.com/rhysd/actionlint in the pre-commit
Fix linting defects
Comment out GitHub composite actions for now. Until we can validate things work as expected.


### Further details

I ran ` pre-commit run --files elastic/active-branches/action.yml` and it reported


```
Validate GitHub Actions..................................................Failed
- hook id: check-github-actions
- exit code: 1

Schema validation errors were encountered.
  elastic/active-branches/action.yml::$.inputs['exclude-branches']: Additional properties are not allowed ('type' was unexpected)
  elastic/active-branches/action.yml::$.inputs['filter-branches'].default: False is not of type 'string'
  elastic/active-branches/action.yml::$.inputs['filter-branches']: Additional properties are not allowed ('type' was unexpected)
  elastic/active-branches/action.yml::$.inputs['github-token']: Additional properties are not allowed ('type' was unexpected)
  elastic/active-branches/action.yml::$.inputs['github-repository']: Additional properties are not allowed ('type' was unexpected)
```

Probably is correct https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs

but let's do the change in a follow-up