### PR TITLE
ci: remove `pull_request_target` and use the job annotations

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   check-labels:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Apply GH security best practices.


No more GH comments but GH check is enough

<img width="1152" height="201" alt="image" src="https://github.com/user-attachments/assets/70db3357-1ee9-4170-af5a-048e62fdce2d" />


<img width="1224" height="410" alt="image" src="https://github.com/user-attachments/assets/8fe15211-0e5e-41f7-bb7b-44e3438b1619" />

