### PR TITLE
Fix for Unused import

### DIFF
--- a/github/backport-active/backport_script.py
+++ b/github/backport-active/backport_script.py
@@ -1,5 +1,4 @@
 import os
-import re
 import json
 import requests
 


### PR DESCRIPTION
The correct fix is to remove the unused `import re` statement from the top of `github/backport-active/backport_script.py`. This change does not affect the rest of the code, which does not reference the `re` module. No additional modifications, imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._