### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/github/backport-active/backport_script.py
+++ b/github/backport-active/backport_script.py
@@ -8,7 +8,6 @@ def main():
     github_token = os.environ['GITHUB_TOKEN']
     pr_number = int(os.environ['PR_NUMBER'])
     repository = os.environ['REPOSITORY']
-    labels_json = os.environ['PR_LABELS']
     backports_url = os.environ['BACKPORTS_URL']
     print(f"Using backports URL: {backports_url}")
 


### PR DESCRIPTION
To fix the problem, simply remove the redundant assignment to `labels_json` on line 11. The second assignment on line 22 correctly initializes `labels_json` with a default value if the environment variable is missing, which is safer than the assignment on line 11 (which could raise a KeyError). No other changes are needed. The change should only be in the region where `labels_json` is assigned for the first time (line 11), and the rest of the logic remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._