### PR TITLE
feat(pagerduty/alert): support integration with pagerduty

### DIFF
--- a/.github/workflows/no-test.yml
+++ b/.github/workflows/no-test.yml
@@ -27,6 +27,7 @@ on:
       - '!oblt-cli/cluster-name-validation/**'
       - '!oblt-cli/list/**'
       - '!oblt-cli/run/**'
+      - '!pagerduty/alert/**'
       - '!pre-commit/**'
       - '!updatecli/run/**'
 

--- a/.github/workflows/test-pagerduty-alert.yml
+++ b/.github/workflows/test-pagerduty-alert.yml
@@ -1,0 +1,33 @@
+name: test-pagerduty-alert
+
+on:
+  merge_group: ~
+  workflow_dispatch: ~
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test-pagerduty-alert.yml'
+      - 'pagerduty/alert/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./pagerduty/alert
+        id: pagerduty-alert
+        with:
+          summary: 'Test Alert from OBLT Actions'
+          source: 'OBLT Actions Test Suite'
+          api-key: ${{ secrets.PD_SECRET }}
+          component: 'OBLT Actions'
+          routing-key: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
+          severity: 'critical'
+
+      - name: Assert output is not empty
+        run: |
+          [ -z "${{ steps.pagerduty-alert.outputs.incident-url }}" ] && exit 1 || exit 0

--- a/.github/workflows/test-pagerduty-alert.yml
+++ b/.github/workflows/test-pagerduty-alert.yml
@@ -25,7 +25,7 @@ jobs:
           source: 'OBLT Actions Test Suite'
           api-key: ${{ secrets.PD_SECRET }}
           component: 'OBLT Actions'
-          routing-key: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
+          routing-key: ${{ secrets.PD_ROUTING_KEY }}
           severity: 'critical'
 
       - name: Assert output is not empty

--- a/.github/workflows/test-pagerduty-alert.yml
+++ b/.github/workflows/test-pagerduty-alert.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./pagerduty/alert
+        if: github.event_name == 'pull_request'
         id: pagerduty-alert
         with:
           summary: 'Test Alert from OBLT Actions'
@@ -29,5 +30,6 @@ jobs:
           severity: 'critical'
 
       - name: Assert output is not empty
+        if: github.event_name == 'pull_request'
         run: |
           [ -n "${{ steps.pagerduty-alert.outputs.incident-url }}" ]

--- a/.github/workflows/test-pagerduty-alert.yml
+++ b/.github/workflows/test-pagerduty-alert.yml
@@ -30,4 +30,4 @@ jobs:
 
       - name: Assert output is not empty
         run: |
-          [ -z "${{ steps.pagerduty-alert.outputs.incident-url }}" ] && exit 1 || exit 0
+          [ -n "${{ steps.pagerduty-alert.outputs.incident-url }}" ]

--- a/pagerduty/alert/README.md
+++ b/pagerduty/alert/README.md
@@ -41,7 +41,7 @@ jobs:
           api-key: "${{ secrets.PD_SECRET }}"
           component: "my-component"
           severity: "critical"
-          routing-key: "abderg1231231312"
+          routing-key: "${{ secrets.PD_ROUTING_KEY }}"
 
       - name: Notify a pagerduty incident has been created
         run: echo "${{steps.pagerduty.outputs.incident-url}} has been created"

--- a/pagerduty/alert/README.md
+++ b/pagerduty/alert/README.md
@@ -1,0 +1,51 @@
+# <!--name-->pagerduty-alert<!--/name-->
+
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2F.github%2Factions%2Fpagerduty%2Falert+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![test-pagerduty-alert](https://github.com/elastic/oblt-actions/actions/workflows/test-pagerduty-alert.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-pagerduty-alert.yml)
+
+<!--description-->
+Raise a PagerDuty
+<!--/description-->
+
+## Inputs
+<!--inputs-->
+| Name          | Description                        | Required | Default    |
+|---------------|------------------------------------|----------|------------|
+| `summary`     | The PagerDuty summary of the alert | `true`   | ` `        |
+| `source`      | The PagerDuty source of the alert  | `true`   | ` `        |
+| `api-key`     | The PagerDuty API key              | `true`   | ` `        |
+| `component`   | The PagerDuty component            | `true`   | ` `        |
+| `routing-key` | The PagerDuty integration key      | `true`   | ` `        |
+| `severity`    | The PagerDuty severity             | `false`  | `critical` |
+<!--/inputs-->
+
+## Outputs
+
+<!--outputs-->
+| Name           | Description                            |
+|----------------|----------------------------------------|
+| `incident-url` | The HTML URL of the PagerDuty incident |
+<!--/outputs-->
+
+## Usage
+<!--usage action="elastic/oblt-actions/**" version="env:VERSION"-->
+```yaml
+jobs:
+  assign-engineer-urgent-now:
+    steps:
+      - uses: elastic/oblt-actions/pagerduty/alert@v1
+        id: pagerduty
+        with:
+          summary: "Reported some errors with XYZ"
+          source: "https://..."
+          api-key: "${{ secrets.PD_SECRET }}"
+          component: "my-component"
+          severity: "critical"
+          routing-key: "abderg1231231312"
+
+      - name: Notify a pagerduty incident has been created
+        run: echo "${{steps.pagerduty.outputs.incident-url}} has been created"
+
+```
+
+<!--/usage-->

--- a/pagerduty/alert/README.md
+++ b/pagerduty/alert/README.md
@@ -1,10 +1,10 @@
 # <!--name-->pagerduty-alert<!--/name-->
 
-[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2F.github%2Factions%2Fpagerduty%2Falert+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
+[![usages](https://img.shields.io/badge/usages-white?logo=githubactions&logoColor=blue)](https://github.com/search?q=elastic%2Foblt-actions%2Fpagerduty%2Falert+%28path%3A.github%2Fworkflows+OR+path%3A**%2Faction.yml+OR+path%3A**%2Faction.yaml%29&type=code)
 [![test-pagerduty-alert](https://github.com/elastic/oblt-actions/actions/workflows/test-pagerduty-alert.yml/badge.svg?branch=main)](https://github.com/elastic/oblt-actions/actions/workflows/test-pagerduty-alert.yml)
 
 <!--description-->
-Raise a PagerDuty
+Raise a PagerDuty alert and return the incident URL
 <!--/description-->
 
 ## Inputs

--- a/pagerduty/alert/action.yml
+++ b/pagerduty/alert/action.yml
@@ -1,5 +1,5 @@
 name: 'pagerduty-alert'
-description: 'Raise a PagerDuty'
+description: 'Raise a PagerDuty alert and return the incident URL'
 inputs:
   summary:
     description: 'The PagerDuty summary of the alert'

--- a/pagerduty/alert/action.yml
+++ b/pagerduty/alert/action.yml
@@ -39,8 +39,10 @@ runs:
           console.log(`sanitized summary is: ${sanitizedTitle}`)
           core.setOutput("summary", sanitizedTitle)
 
+          // Time window (15 minutes) for searching recent incidents, in milliseconds
+          const SEARCH_WINDOW_MS = 15 * 60 * 1000;
           const now = new Date()
-          const fifteenMinutesAgo = new Date(now.getTime() - (15 * 60 * 1000))
+          const fifteenMinutesAgo = new Date(now.getTime() - SEARCH_WINDOW_MS)
           const isoDate = fifteenMinutesAgo.toISOString()
           core.setOutput("time-search", isoDate)
 

--- a/pagerduty/alert/action.yml
+++ b/pagerduty/alert/action.yml
@@ -1,0 +1,81 @@
+name: 'pagerduty-alert'
+description: 'Raise a PagerDuty'
+inputs:
+  summary:
+    description: 'The PagerDuty summary of the alert'
+    required: true
+  source:
+    description: 'The PagerDuty source of the alert'
+    required: true
+  api-key:
+    description: 'The PagerDuty API key'
+    required: true
+  component:
+    description: 'The PagerDuty component'
+    required: true
+  routing-key:
+    description: 'The PagerDuty integration key'
+    required: true
+  severity:
+    description: 'The PagerDuty severity'
+    default: 'critical'
+    required: false
+
+outputs:
+  incident-url:
+    description: 'The HTML URL of the PagerDuty incident'
+    value: ${{ steps.get_incident.outputs.result }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v8
+      id: sanitize
+      env:
+        SUMMARY: ${{ inputs.summary }}
+      with:
+        script: |
+          const sanitizedTitle = JSON.stringify(process.env.SUMMARY).slice(1, -1)
+          console.log(`sanitized summary is: ${sanitizedTitle}`)
+          core.setOutput("summary", sanitizedTitle)
+
+          const now = new Date()
+          const fifteenMinutesAgo = new Date(now.getTime() - (15 * 60 * 1000))
+          const isoDate = fifteenMinutesAgo.toISOString()
+          core.setOutput("time-search", isoDate)
+
+    - name: Trigger PagerDuty Alert
+      uses: fjogeleit/http-request-action@1297c6fc63a79b147d1676540a3fd9d2e37817c5 # v1.16.5
+      with:
+        url: 'https://events.pagerduty.com/v2/enqueue'
+        method: 'POST'
+        customHeaders: '{"Accept": "application/json", "Content-Type": "application/json", "Authorization" : "Token token=${{ inputs.api-key }}"}'
+        data: '{"event_action": "trigger", "routing_key": "${{ inputs.routing-key }}", "payload": {"summary": "${{steps.sanitize.outputs.summary}}", "source": "${{ inputs.source }}", "custom_details":"${{ inputs.source }}", "severity": "${{ inputs.severity }}", "component": "${{ inputs.component }}"}}'
+
+    - name: Fetch PagerDuty Incidents
+      id: pagerduty_incident
+      uses: fjogeleit/http-request-action@1297c6fc63a79b147d1676540a3fd9d2e37817c5 # v1.16.5
+      with:
+        url: 'https://api.pagerduty.com/incidents?since=${{steps.sanitize.outputs.time-search}}&statuses[]=triggered&statuses[]=acknowledged'
+        method: 'GET'
+        customHeaders: '{"Accept": "application/json", "Content-Type": "application/json", "Authorization" : "Token token=${{ inputs.api-key }}"}'
+
+    - name: Search the incident
+      uses: actions/github-script@v8
+      id: get_incident
+      env:
+        SUMMARY: ${{ steps.sanitize.outputs.summary }}
+      with:
+        script: |
+          const responseData = `${{ steps.pagerduty_incident.outputs.response }}`
+          const parsedData = JSON.parse(responseData)
+          const summary = process.env.SUMMARY
+          const specificIncident = parsedData.incidents.find(incident => incident.title === summary)
+          if (specificIncident) {
+            console.log(`Found HTML URL: ${specificIncident.html_url}`)
+            return specificIncident.html_url
+          } else {
+            console.log('No incident found.')
+            return ''
+          }
+        result-encoding: string

--- a/pagerduty/alert/action.yml
+++ b/pagerduty/alert/action.yml
@@ -40,9 +40,8 @@ runs:
           core.setOutput("summary", sanitizedTitle)
 
           // Time window (15 minutes) for searching recent incidents, in milliseconds
-          const SEARCH_WINDOW_MS = 15 * 60 * 1000;
           const now = new Date()
-          const fifteenMinutesAgo = new Date(now.getTime() - SEARCH_WINDOW_MS)
+          const fifteenMinutesAgo = new Date(now.getTime() - (15 * 60 * 1000))
           const isoDate = fifteenMinutesAgo.toISOString()
           core.setOutput("time-search", isoDate)
 


### PR DESCRIPTION
See https://developer.pagerduty.com/api-reference/368ae3d938c9e-send-an-event-to-pager-duty


Initially implemented at https://github.com/elastic/app-obs-dev/tree/main/.github/actions/pagerduty-alert

But decided to create a fork so we can keep its maintenance outside of the SDH automation



It worked fine

<img width="966" height="285" alt="image" src="https://github.com/user-attachments/assets/b7342214-8983-42b7-aafa-605d989b3512" />
