### PR TITLE
fix waitfor multiple retries

### DIFF
--- a/buildkite/run/wait-for.sh
+++ b/buildkite/run/wait-for.sh
@@ -21,14 +21,20 @@ STATE="running"
 echo "Waiting for build $WEB_URL to run "
 # https://buildkite.com/docs/pipelines/defining-steps#build-states
 while [ "$STATE" == "running" ] || [ "$STATE" == "scheduled" ] || [ "$STATE" == "creating" ]; do
-  RESP=$(curl \
+  # use a temporary file for output to only get the latest attempt output
+  # --retry-all-errors may produce duplicated output as indicated in 
+  # https://curl.se/docs/manpage.html#--retry-all-errors
+  RESP_FILE=$(mktemp)
+  curl \
     -H "Authorization: Bearer $BK_TOKEN" \
     --no-progress-meter \
     --retry 5 \
     --retry-delay 5 \
     --retry-all-errors \
-    "$URL")
-  STATE=$(echo "$RESP" | jq -r ".state")
+    -o "$RESP_FILE" \
+    "$URL"
+  STATE=$(jq -r ".state" "$RESP_FILE")
+  rm -f "$RESP_FILE"
   echo -n "."
   sleep 1
 done

--- a/buildkite/run/wait-for.sh
+++ b/buildkite/run/wait-for.sh
@@ -22,7 +22,7 @@ echo "Waiting for build $WEB_URL to run "
 # https://buildkite.com/docs/pipelines/defining-steps#build-states
 while [ "$STATE" == "running" ] || [ "$STATE" == "scheduled" ] || [ "$STATE" == "creating" ]; do
   # use a temporary file for output to only get the latest attempt output
-  # --retry-all-errors may produce duplicated output as indicated in 
+  # --retry-all-errors may produce duplicated output as indicated in
   # https://curl.se/docs/manpage.html#--retry-all-errors
   RESP_FILE=$(mktemp)
   curl \


### PR DESCRIPTION
- **make wait-for.sh use latest response only**

Fixes https://github.com/elastic/elastic-otel-java/issues/1071

https://github.com/elastic/elastic-otel-java/actions/runs/24981115933/job/73143557930

We can see in the output that the multiple HTTP calls results get concatenated:

```
Build did not pass, it's 'null
null
null
null
running'. Check the logs at https://buildkite.com/elastic/elastic-otel-java-snapshot/builds/850
```

Here the result of the API call should have been `running`.
